### PR TITLE
MonteCarloObservables deprecations

### DIFF
--- a/src/flavors/DQMC/DQMC.jl
+++ b/src/flavors/DQMC/DQMC.jl
@@ -155,7 +155,7 @@ function run!(mc::DQMC; verbose::Bool=true, sweeps::Int=mc.p.sweeps, thermalizat
         if mod(i, 10) == 0
             mc.a.acc_rate = mc.a.acc_rate / (10 * 2 * mc.p.slices)
             mc.a.acc_rate_global = mc.a.acc_rate_global / (10 / mc.p.global_rate)
-            add!(sweep_dur, (time() - _time)/10)
+            push!(sweep_dur, (time() - _time)/10)
             if verbose
                 println("\t", i)
                 @printf("\t\tsweep dur: %.3fs\n", sweep_dur[end])

--- a/src/flavors/MC/MC.jl
+++ b/src/flavors/MC/MC.jl
@@ -123,7 +123,7 @@ function run!(mc::MC; verbose::Bool=true, sweeps::Int=mc.p.sweeps, thermalizatio
         if mod(i, 1000) == 0
             mc.a.acc_rate = mc.a.acc_rate / 1000
             mc.a.acc_rate_global = mc.a.acc_rate_global / (1000 / mc.p.global_rate)
-            add!(sweep_dur, (time() - _time)/1000)
+            push!(sweep_dur, (time() - _time)/1000)
             if verbose
                 println("\t", i)
                 @printf("\t\tsweep dur: %.3fs\n", sweep_dur[end])

--- a/src/models/HubbardAttractive/observables.jl
+++ b/src/models/HubbardAttractive/observables.jl
@@ -21,11 +21,11 @@ Measures observables and updates corresponding `Observable` objects in `obs`.
 
 See also [`prepare_observables`](@ref) and [`finish_observables!`](@ref).
 """
-@noinline function measure_observables!(mc::DQMC, m::HubbardModelAttractive, 
+@noinline function measure_observables!(mc::DQMC, m::HubbardModelAttractive,
 							obs::Dict{String,Observable}, conf::HubbardConf)
-    add!(obs["confs"], mc.conf)
-    add!(obs["greens"], greens(mc))
-    add!(obs["Eboson"], mc.energy_boson)
+    push!(obs["confs"], mc.conf)
+    push!(obs["greens"], greens(mc))
+    push!(obs["Eboson"], mc.energy_boson)
     nothing
 end
 
@@ -36,7 +36,7 @@ Finish measurements of observables.
 
 See also [`prepare_observables`](@ref) and [`measure_observables!`](@ref).
 """
-@inline function finish_observables!(mc::DQMC, m::HubbardModelAttractive, 
+@inline function finish_observables!(mc::DQMC, m::HubbardModelAttractive,
 							obs::Dict{String,Observable})
     nothing
 end

--- a/src/models/Ising/IsingModel.jl
+++ b/src/models/Ising/IsingModel.jl
@@ -194,20 +194,20 @@ See also [`prepare_observables`](@ref) and [`finish_observables!`](@ref).
 @inline function measure_observables!(mc::MC, m::IsingModel, obs::Dict{String,Observable}, conf::IsingConf, E::Float64)
   N = m.l.sites
 
-    add!(obs["confs"], conf)
+    push!(obs["confs"], conf)
 
     # energie
     E2 = E^2
-    add!(obs["E"], E)
-    add!(obs["E2"], E2)
-    add!(obs["e"], E/N)
+    push!(obs["E"], E)
+    push!(obs["E2"], E2)
+    push!(obs["e"], E/N)
 
     # magnetization
     M::Float64 = abs(sum(conf))
     M2 = M^2
-    add!(obs["M"], M)
-    add!(obs["M2"], M2)
-    add!(obs["m"], M/N)
+    push!(obs["M"], M)
+    push!(obs["M2"], M2)
+    push!(obs["m"], M/N)
 
     nothing
 end
@@ -226,12 +226,12 @@ See also [`prepare_observables`](@ref) and [`measure_observables!`](@ref).
     # specific heat
   E = mean(obs["E"])
   E2 = mean(obs["E2"])
-    add!(obs["C"], beta*beta*(E2/N - E*E/N))
+    push!(obs["C"], beta*beta*(E2/N - E*E/N))
 
     # susceptibility
   M = mean(obs["M"])
   M2 = mean(obs["M2"])
-    add!(obs["χ"], beta*(M2/N - M*M/N))
+    push!(obs["χ"], beta*(M2/N - M*M/N))
 
     nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,7 @@ using Random
             m = mc.obs["m"] # magnetization
 
             @test isapprox(0.398, round(mean(m), digits=3))
-            @test isapprox(0.012, round(error(m), digits=3))
+            @test isapprox(0.013, round(std_error(m), digits=3))
             @test typeof(observables(mc)) == Dict{String, String}
         end
     end


### PR DESCRIPTION
Fixes deprecation warning of `add!(o, ...)` and `error(o)`. Also fixes failure of Ising test. Can be merged if tests succeed.