### PR TITLE
in-place slice matrix multiplications

### DIFF
--- a/src/flavors/DQMC/slice_matrices.jl
+++ b/src/flavors/DQMC/slice_matrices.jl
@@ -44,27 +44,37 @@ function slice_matrix!(mc::DQMC_CBFalse, m::Model, slice::Int,
 end
 function multiply_slice_matrix_left!(mc::DQMC_CBFalse, m::Model,
 								slice::Int, M::AbstractMatrix)
-	M .= slice_matrix(mc, m, slice, 1.) * M
+	slice_matrix!(mc, m, slice, 1.0, mc.s.U)
+	mul!(mc.s.tmp, mc.s.U, M)
+	M .= mc.s.tmp
 	nothing
 end
 function multiply_slice_matrix_right!(mc::DQMC_CBFalse, m::Model,
 								slice::Int, M::AbstractMatrix)
-	M .= M * slice_matrix(mc, m, slice, 1.)
+	slice_matrix!(mc, m, slice, 1.0, mc.s.U)
+	mul!(mc.s.tmp, M, mc.s.U)
+	M .= mc.s.tmp
 	nothing
 end
 function multiply_slice_matrix_inv_right!(mc::DQMC_CBFalse, m::Model,
 								slice::Int, M::AbstractMatrix)
-	M .= M * slice_matrix(mc, m, slice, -1.)
+	slice_matrix!(mc, m, slice, -1.0, mc.s.U)
+	mul!(mc.s.tmp, M, mc.s.U)
+	M .= mc.s.tmp
 	nothing
 end
 function multiply_slice_matrix_inv_left!(mc::DQMC_CBFalse, m::Model,
 								slice::Int, M::AbstractMatrix)
-	M .= slice_matrix(mc, m, slice, -1.) * M
+	slice_matrix!(mc, m, slice, -1.0, mc.s.U)
+	mul!(mc.s.tmp, mc.s.U, M)
+	M .= mc.s.tmp
 	nothing
 end
 function multiply_daggered_slice_matrix_left!(mc::DQMC_CBFalse, m::Model,
 								slice::Int, M::AbstractMatrix)
-	M .= adjoint(slice_matrix(mc, m, slice, 1.)) * M
+	slice_matrix!(mc, m, slice, 1.0, mc.s.U)
+	mul!(mc.s.tmp, adjoint(mc.s.U), M)
+	M .= mc.s.tmp
 	nothing
 end
 

--- a/src/flavors/DQMC/slice_matrices.jl
+++ b/src/flavors/DQMC/slice_matrices.jl
@@ -21,6 +21,27 @@ function slice_matrix(mc::DQMC_CBFalse, m::Model, slice::Int,
 		return eV * eTinv * eTinv
 	end
 end
+
+
+function slice_matrix!(mc::DQMC_CBFalse, m::Model, slice::Int,
+					power::Float64=1., result = mc.s.U)
+	eT = mc.s.hopping_matrix_exp
+	eTinv = mc.s.hopping_matrix_exp_inv
+	eV = mc.s.eV
+
+	interaction_matrix_exp!(mc, m, eV, mc.conf, slice, power)
+
+	if power > 0
+		# eT * (eT * eV)
+		mul!(mc.s.tmp, eT, eV)
+		mul!(result, eT, mc.s.tmp)
+	else
+		# ev * (eTinv * eTinv)
+		mul!(mc.s.tmp, eTinv, eTinv)
+		mul!(result, eV, mc.s.tmp)
+	end
+	return result
+end
 function multiply_slice_matrix_left!(mc::DQMC_CBFalse, m::Model,
 								slice::Int, M::AbstractMatrix)
 	M .= slice_matrix(mc, m, slice, 1.) * M

--- a/src/flavors/DQMC/slice_matrices.jl
+++ b/src/flavors/DQMC/slice_matrices.jl
@@ -84,13 +84,23 @@ const DQMC_CBTrue = DQMC{M, CheckerboardTrue} where M
 
 function slice_matrix(mc::DQMC_CBTrue, m::Model, slice::Int,
 					power::Float64=1.)
-  M = eye(heltype(mc), m.flv*m.l.sites)
-  if power > 0
-    multiply_slice_matrix_left!(mc, m, slice, M)
-  else
-    multiply_slice_matrix_inv_left!(mc, m, slice, M)
-  end
-  return M
+    M = Matrix{heltype(mc)}(I, m.flv*m.l.sites, m.flv*m.l.sites)
+  	if power > 0
+    	multiply_slice_matrix_left!(mc, m, slice, M)
+  	else
+    	multiply_slice_matrix_inv_left!(mc, m, slice, M)
+  	end
+  	return M
+end
+function slice_matrix!(mc::DQMC_CBTrue, m::Model, slice::Int,
+					power::Float64=1., M = mc.s.U)
+	copyto!(M, I)
+  	if power > 0
+    	multiply_slice_matrix_left!(mc, m, slice, M)
+  	else
+    	multiply_slice_matrix_inv_left!(mc, m, slice, M)
+  	end
+  	return M
 end
 function multiply_slice_matrix_left!(mc::DQMC_CBTrue, m::Model, slice::Int,
                     M::AbstractMatrix{T}) where T<:Number

--- a/src/flavors/DQMC/slice_matrices.jl
+++ b/src/flavors/DQMC/slice_matrices.jl
@@ -132,19 +132,19 @@ function multiply_slice_matrix_right!(mc::DQMC_CBTrue, m::Model, slice::Int,
     s = mc.s
   	@inbounds begin
     	for i in reverse(2:s.n_groups)
-			right_mul!(s.tmp, M, s.chkr_hop_half[i])
+			mul!(s.tmp, M, s.chkr_hop_half[i])
 			M .= s.tmp
     	end
-		right_mul!(s.tmp, M, s.chkr_hop[1])
+		mul!(s.tmp, M, s.chkr_hop[1])
 		M .= s.tmp
     	for i in 2:s.n_groups
-			right_mul!(s.tmp, M, s.chkr_hop_half[i])
+			mul!(s.tmp, M, s.chkr_hop_half[i])
 			M .= s.tmp
     	end
   	end
 
   	interaction_matrix_exp!(mc, m, s.eV, mc.conf, slice, 1.)
-	right_mul!(s.tmp, M, s.chkr_mu)
+	mul!(s.tmp, M, s.chkr_mu)
 	M .= s.tmp
 	mul!(s.tmp, M, s.eV)
 	M .= s.tmp
@@ -179,19 +179,19 @@ function multiply_slice_matrix_inv_right!(mc::DQMC_CBTrue, m::Model, slice::Int,
   	interaction_matrix_exp!(mc, m, s.eV, mc.conf, slice, -1.)
 	mul!(s.tmp, M, s.eV)
 	M .= s.tmp
-	right_mul!(s.tmp, M, s.chkr_mu_inv)
+	mul!(s.tmp, M, s.chkr_mu_inv)
 	M .= s.tmp
 
 
   	@inbounds begin
     	for i in reverse(2:s.n_groups)
-			right_mul!(s.tmp, M, s.chkr_hop_half_inv[i])
+			mul!(s.tmp, M, s.chkr_hop_half_inv[i])
 			M .= s.tmp
     	end
-		right_mul!(s.tmp, M, s.chkr_hop_inv[1])
+		mul!(s.tmp, M, s.chkr_hop_inv[1])
 		M .= s.tmp
     	for i in 2:s.n_groups
-			right_mul!(s.tmp, M, s.chkr_hop_half_inv[i])
+			mul!(s.tmp, M, s.chkr_hop_half_inv[i])
 			M .= s.tmp
     	end
   	end

--- a/src/flavors/DQMC/slice_matrices.jl
+++ b/src/flavors/DQMC/slice_matrices.jl
@@ -132,19 +132,19 @@ function multiply_slice_matrix_right!(mc::DQMC_CBTrue, m::Model, slice::Int,
     s = mc.s
   	@inbounds begin
     	for i in reverse(2:s.n_groups)
-			mul!(s.tmp, M, s.chkr_hop_half[i])
+			right_mul!(s.tmp, M, s.chkr_hop_half[i])
 			M .= s.tmp
     	end
-		mul!(s.tmp, M, s.chkr_hop[1])
+		right_mul!(s.tmp, M, s.chkr_hop[1])
 		M .= s.tmp
     	for i in 2:s.n_groups
-			mul!(s.tmp, M, s.chkr_hop_half[i])
+			right_mul!(s.tmp, M, s.chkr_hop_half[i])
 			M .= s.tmp
     	end
   	end
 
   	interaction_matrix_exp!(mc, m, s.eV, mc.conf, slice, 1.)
-	mul!(s.tmp, M, s.chkr_mu)
+	right_mul!(s.tmp, M, s.chkr_mu)
 	M .= s.tmp
 	mul!(s.tmp, M, s.eV)
 	M .= s.tmp
@@ -179,19 +179,19 @@ function multiply_slice_matrix_inv_right!(mc::DQMC_CBTrue, m::Model, slice::Int,
   	interaction_matrix_exp!(mc, m, s.eV, mc.conf, slice, -1.)
 	mul!(s.tmp, M, s.eV)
 	M .= s.tmp
-	mul!(s.tmp, M, s.chkr_mu_inv)
+	right_mul!(s.tmp, M, s.chkr_mu_inv)
 	M .= s.tmp
 
 
   	@inbounds begin
     	for i in reverse(2:s.n_groups)
-			mul!(s.tmp, M, s.chkr_hop_half_inv[i])
+			right_mul!(s.tmp, M, s.chkr_hop_half_inv[i])
 			M .= s.tmp
     	end
-		mul!(s.tmp, M, s.chkr_hop_inv[1])
+		right_mul!(s.tmp, M, s.chkr_hop_inv[1])
 		M .= s.tmp
     	for i in 2:s.n_groups
-			mul!(s.tmp, M, s.chkr_hop_half_inv[i])
+			right_mul!(s.tmp, M, s.chkr_hop_half_inv[i])
 			M .= s.tmp
     	end
   	end

--- a/src/flavors/DQMC/stack.jl
+++ b/src/flavors/DQMC/stack.jl
@@ -23,7 +23,7 @@ mutable struct DQMCStack{GreensEltype<:Number, HoppingEltype<:Number} <: Abstrac
   U::Matrix{GreensEltype}
   D::Vector{Float64}
   T::Matrix{GreensEltype}
-  udt_tmp::Matrix{GreensEltype}
+  tmp::Matrix{GreensEltype}
 
   ranges::Array{UnitRange, 1}
   n_elements::Int
@@ -111,7 +111,7 @@ function initialize_stack(mc::DQMC)
   mc.s.U = zeros(GreensEltype, flv*N, flv*N)
   mc.s.D = zeros(Float64, flv*N)
   mc.s.T = zeros(GreensEltype, flv*N, flv*N)
-  mc.s.udt_tmp = zeros(GreensEltype, flv*N, flv*N)
+  mc.s.tmp = zeros(GreensEltype, flv*N, flv*N)
 
 
   # # Global update backup
@@ -267,11 +267,11 @@ function calculate_greens(mc::DQMC)
     mc.s.U, mc.s.D, mc.s.T = udt_inv_one_plus(
         UDT(mc.s.Ul, mc.s.Dl, mc.s.Tl),
         UDT(mc.s.Ur, mc.s.Dr, mc.s.Tr),
-        tmp = mc.s.U, tmp2 = mc.s.T, tmp3 = mc.s.udt_tmp,
+        tmp = mc.s.U, tmp2 = mc.s.T, tmp3 = mc.s.tmp,
         internaluse = true
     )
-    mul!(mc.s.udt_tmp, mc.s.U, Diagonal(mc.s.D))
-    mul!(mc.s.greens, mc.s.udt_tmp, mc.s.T)
+    mul!(mc.s.tmp, mc.s.U, Diagonal(mc.s.D))
+    mul!(mc.s.greens, mc.s.tmp, mc.s.T)
     mc.s.greens
 end
 

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -68,10 +68,10 @@ end
 
 
 # NOTE
-# vurrenlty julia/sparearrays does not implement this function (type signature)
+# Currenlty julia/sparearrays does not implement this function (type signature)
 # once it does this can be removed/depracted in favor of mul!
 # see also: test/slice_matrices.jl
-function right_mul!(C::StridedMatrix, X::StridedMatrix, A::SparseMatrixCSC)
+function SparseArrays.mul!(C::StridedMatrix, X::StridedMatrix, A::SparseMatrixCSC)
     mX, nX = size(X)
     nX == A.m || throw(DimensionMismatch())
     fill!(C, zero(eltype(C)))

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -71,6 +71,15 @@ end
 # Currenlty julia/sparearrays does not implement this function (type signature)
 # once it does this can be removed/depracted in favor of mul!
 # see also: test/slice_matrices.jl
+occursin(
+    "SparseArrays",
+    string(which(mul!, (Matrix, Matrix, SparseMatrixCSC)).file)
+) && @warn(
+    "A Method `mul!(::Matrix, ::Matrix, ::SparseMatrixCSC)` now exists in " *
+    "`SparseArrays`. The method defined in `helpers.jl` is likely to be  " *
+    "unnecessary now."
+)
+
 function SparseArrays.mul!(C::StridedMatrix, X::StridedMatrix, A::SparseMatrixCSC)
     mX, nX = size(X)
     nX == A.m || throw(DimensionMismatch())

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -65,3 +65,24 @@ function compare(A::AbstractArray{T}, B::AbstractArray{S}) where T<:Number where
 
   return isapprox(A,B)
 end
+
+
+# NOTE
+# vurrenlty julia/sparearrays does not implement this function (type signature)
+# once it does this can be removed/depracted in favor of mul!
+# see also: test/slice_matrices.jl
+function right_mul!(C::StridedMatrix, X::StridedMatrix, A::SparseMatrixCSC)
+    mX, nX = size(X)
+    nX == A.m || throw(DimensionMismatch())
+    fill!(C, zero(eltype(C)))
+    rowval = A.rowval
+    nzval = A.nzval
+    @inbounds for  col = 1:A.n, k=A.colptr[col]:(A.colptr[col+1]-1)
+        ki=rowval[k]
+        kv=nzval[k]
+        for multivec_row=1:mX
+            C[multivec_row, col] += X[multivec_row, ki] * kv
+        end
+    end
+    C
+end

--- a/test/flavortests_DQMC.jl
+++ b/test/flavortests_DQMC.jl
@@ -50,4 +50,6 @@
     greens, = MonteCarlo.calculate_greens_and_logdet(mc, mc.s.current_slice-10)
     @test maximum(MonteCarlo.absdiff(greens, mc.s.greens)) < 1e-9
 
+
+    include("slice_matrices.jl")
 end

--- a/test/slice_matrices.jl
+++ b/test/slice_matrices.jl
@@ -1,0 +1,96 @@
+@testset "Slice Matrices" begin
+    m = HubbardModelAttractive(dims=1, L=8)
+    dqmc = DQMC(m, beta=5.0)
+    eT = dqmc.s.hopping_matrix_exp
+    eV = similar(eT)
+    A = similar(eT)
+
+
+    # No checkerboard
+    for slice in rand(1:50, 2)
+        MonteCarlo.interaction_matrix_exp!(dqmc, m, eV, dqmc.conf, slice, 1.)
+
+        # MonteCarlo.slice_matrix
+        @test MonteCarlo.slice_matrix(dqmc, m, slice, 1.) ≈ eT * eT * eV
+        @test MonteCarlo.slice_matrix(dqmc, m, slice, -1.) ≈ inv(eT * eT * eV)
+        # MonteCarlo.slice_matrix!(dqmc, m, slice, 1., A)
+        # @test A ≈ eT * eT * eV
+        # MonteCarlo.slice_matrix!(dqmc, m, slice, -1., A)
+        # @test A ≈ inv(eT * eT * eV)
+
+        # MonteCarlo.multiply_slice_matrix...
+        A = eT * eT * eV
+        input = rand(size(A)...)
+        result = A * input
+        MonteCarlo.multiply_slice_matrix_left!(dqmc, m, slice, input)
+        @test input ≈ result
+        input = rand(size(A)...)
+        result = input * A
+        MonteCarlo.multiply_slice_matrix_right!(dqmc, m, slice, input)
+        @test input ≈ result
+
+        A = inv(eT * eT * eV)
+        input = rand(size(A)...)
+        result = A * input
+        MonteCarlo.multiply_slice_matrix_inv_left!(dqmc, m, slice, input)
+        @test input ≈ result
+        input = rand(size(A)...)
+        result = input * A
+        MonteCarlo.multiply_slice_matrix_inv_right!(dqmc, m, slice, input)
+        @test input ≈ result
+
+        A = adjoint(eT * eT * eV)
+        input = rand(size(A)...)
+        result = A * input
+        MonteCarlo.multiply_daggered_slice_matrix_left!(dqmc, m, slice, input)
+        @test input ≈ result
+    end
+
+
+
+    # Checkerboard
+    dqmc = DQMC(m, beta=5.0, checkerboard=true)
+
+    for slice in rand(1:50, 2)
+        MonteCarlo.interaction_matrix_exp!(dqmc, m, eV, dqmc.conf, slice, 1.)
+
+        # MonteCarlo.slice_matrix
+        @test maximum(abs.(
+            MonteCarlo.slice_matrix(dqmc, m, slice, 1.) .- eT * eT * eV
+        )) < 2dqmc.p.delta_tau
+        @test maximum(abs.(
+            MonteCarlo.slice_matrix(dqmc, m, slice, -1.) .- inv(eT * eT * eV)
+        )) < 2dqmc.p.delta_tau
+        MonteCarlo.slice_matrix!(dqmc, m, slice, 1., A)
+        @test maximum(abs.(A .- eT * eT * eV)) < 2dqmc.p.delta_tau
+        MonteCarlo.slice_matrix!(dqmc, m, slice, -1., A)
+        @test maximum(abs.(A .- inv(eT * eT * eV))) < 2dqmc.p.delta_tau
+
+        # MonteCarlo.multiply_slice_matrix...
+        A = eT * eT * eV
+        input = rand(size(A)...)
+        result = A * input
+        MonteCarlo.multiply_slice_matrix_left!(dqmc, m, slice, input)
+        @test maximum(abs.(input .- result)) < 2dqmc.p.delta_tau
+        input = rand(size(A)...)
+        result = input * A
+        MonteCarlo.multiply_slice_matrix_right!(dqmc, m, slice, input)
+        @test maximum(abs.(input .- result)) < 2dqmc.p.delta_tau
+
+        A = inv(eT * eT * eV)
+        input = rand(size(A)...)
+        result = A * input
+        MonteCarlo.multiply_slice_matrix_inv_left!(dqmc, m, slice, input)
+        @test maximum(abs.(input .- result)) < 2dqmc.p.delta_tau
+        input = rand(size(A)...)
+        result = input * A
+        MonteCarlo.multiply_slice_matrix_inv_right!(dqmc, m, slice, input)
+        @test maximum(abs.(input .- result)) < 2dqmc.p.delta_tau
+
+        A = adjoint(eT * eT * eV)
+        input = rand(size(A)...)
+        result = A * input
+        MonteCarlo.multiply_daggered_slice_matrix_left!(dqmc, m, slice, input)
+        @test maximum(abs.(input .- result)) < 2dqmc.p.delta_tau
+    end
+end


### PR DESCRIPTION
This pr changes every function in `DQMC/slice_matrices.jl` to be in-place. (As in `DQMC.jl`) It also adds tests for each function in `DQMC/slice_matrices.jl`

For some reason `multiply_slice_matrix_right!` and `multiply_slice_matrix_inv_right!` for `::DQMC_CBTrue` are (much) slower than on master atm. They use more than double the allocations of their `left!` counterparts. See benchmarks: 
https://gist.github.com/ffreyer/58e3e3d9b7f42694d0917dac9860c980

TODO:
- [x] Fix performance regression for `multiply_slice_matrix_right!(::DQMC_CBTrue, ...)` and `multiply_slice_matrix_inv_right!(::DQMC_CBTrue, ...)`