### PR TITLE
improve `interaction_matrix_exp!` performance

### DIFF
--- a/src/MonteCarlo.jl
+++ b/src/MonteCarlo.jl
@@ -8,6 +8,8 @@ using JLD
 
 using Printf, SparseArrays, LinearAlgebra, Dates, Random
 
+using TimerOutputs
+const to = TimerOutput()
 
 include("flavors/abstract.jl")
 include("models/abstract.jl")

--- a/src/MonteCarlo.jl
+++ b/src/MonteCarlo.jl
@@ -8,8 +8,6 @@ using JLD
 
 using Printf, SparseArrays, LinearAlgebra, Dates, Random
 
-using TimerOutputs
-const to = TimerOutput()
 
 include("flavors/abstract.jl")
 include("models/abstract.jl")

--- a/src/flavors/DQMC/DQMC.jl
+++ b/src/flavors/DQMC/DQMC.jl
@@ -204,7 +204,6 @@ Progress will be printed to `stdout` if `verbose=true` (default).
 function run!(mc::DQMC; verbose::Bool=true, sweeps::Int=mc.p.sweeps,
         thermalization=mc.p.thermalization)
 
-    @timeit to "run!" begin
     do_th_measurements = !isempty(mc.thermalization_measurements)
     do_me_measurements = !isempty(mc.measurements)
     !do_me_measurements && @warn(
@@ -275,7 +274,6 @@ function run!(mc::DQMC; verbose::Bool=true, sweeps::Int=mc.p.sweeps,
     end_time = now()
     verbose && println("Ended: ", Dates.format(end_time, "d.u yyyy HH:MM"))
     verbose && @printf("Duration: %.2f minutes", (end_time - start_time).value/1000. /60.)
-    end
     nothing
 end
 

--- a/src/flavors/DQMC/DQMC.jl
+++ b/src/flavors/DQMC/DQMC.jl
@@ -21,18 +21,18 @@ struct DQMCParameters
     thermalization::Int
     sweeps::Int
     all_checks::Bool
-    safe_mult::Int 
+    safe_mult::Int
     delta_tau::Float64
     beta::Float64
-    slices::Int 
+    slices::Int
     measure_rate::Int
 end
 
 function DQMCParameters(;global_moves::Bool = false,
                         global_rate::Int    = 5,
-                        thermalization::Int = 100, 
+                        thermalization::Int = 100,
                         sweeps::Int         = 100,
-                        all_checks::Bool    = true, 
+                        all_checks::Bool    = true,
                         safe_mult::Int      = 10,
                         measure_rate::Int   = 10,
                         warn_round::Bool    = true,
@@ -58,10 +58,10 @@ function DQMCParameters(;global_moves::Bool = false,
                    thermalization,
                    sweeps,
                    all_checks,
-                   safe_mult, 
+                   safe_mult,
                    delta_tau,
                    beta,
-                   slices, 
+                   slices,
                    measure_rate)
 end
 
@@ -204,6 +204,7 @@ Progress will be printed to `stdout` if `verbose=true` (default).
 function run!(mc::DQMC; verbose::Bool=true, sweeps::Int=mc.p.sweeps,
         thermalization=mc.p.thermalization)
 
+    @timeit to "run!" begin
     do_th_measurements = !isempty(mc.thermalization_measurements)
     do_me_measurements = !isempty(mc.measurements)
     !do_me_measurements && @warn(
@@ -274,7 +275,7 @@ function run!(mc::DQMC; verbose::Bool=true, sweeps::Int=mc.p.sweeps,
     end_time = now()
     verbose && println("Ended: ", Dates.format(end_time, "d.u yyyy HH:MM"))
     verbose && @printf("Duration: %.2f minutes", (end_time - start_time).value/1000. /60.)
-
+    end
     nothing
 end
 

--- a/src/models/HubbardAttractive/HubbardModelAttractive.jl
+++ b/src/models/HubbardAttractive/HubbardModelAttractive.jl
@@ -118,26 +118,15 @@ This is a performance critical method.
 @inline function interaction_matrix_exp!(mc::DQMC, m::HubbardModelAttractive,
             result::Matrix, conf::HubbardConf, slice::Int, power::Float64=1.)
 
-    @timeit to "interaction_matrix_exp! old" begin
-        dtau = mc.p.delta_tau
-        lambda = acosh(exp(m.U * dtau/2))
-        result .= spdiagm(0 => exp.(sign(power) * lambda * conf[:,slice]))
+
+    dtau = mc.p.delta_tau
+    lambda = acosh(exp(0.5m.U * dtau))
+
+    result .= zero(eltype(result))
+    N = size(result, 1)
+    @inbounds for i in 1:N
+        result[i, i] = exp(sign(power) * lambda * conf[i, slice])
     end
-
-    temp = deepcopy(result)
-
-    @timeit to "interaction_matrix_exp! new" begin
-        dtau = mc.p.delta_tau
-        lambda = acosh(exp(0.5m.U * dtau))
-
-        result .= zero(eltype(result))
-        N = size(result, 1)
-        @inbounds for i in 1:N
-            result[i, i] = exp(sign(power) * lambda * conf[i, slice])
-        end
-    end
-
-    @assert temp ≈ result
     nothing
 end
 

--- a/src/models/HubbardAttractive/HubbardModelAttractive.jl
+++ b/src/models/HubbardAttractive/HubbardModelAttractive.jl
@@ -107,20 +107,10 @@ and store it in `result::Matrix`.
 
 This is a performance critical method.
 """
-# @inline function interaction_matrix_exp!(mc::DQMC, m::HubbardModelAttractive,
-#             result::Matrix, conf::HubbardConf, slice::Int, power::Float64=1.)
-#     dtau = mc.p.delta_tau
-#     lambda = acosh(exp(m.U * dtau/2))
-#     result .= spdiagm(0 => exp.(sign(power) * lambda * conf[:,slice]))
-#     nothing
-# end
-
 @inline function interaction_matrix_exp!(mc::DQMC, m::HubbardModelAttractive,
             result::Matrix, conf::HubbardConf, slice::Int, power::Float64=1.)
-
-
     dtau = mc.p.delta_tau
-    lambda = acosh(exp(0.5m.U * dtau))
+    lambda = acosh(exp(0.5 * m.U * dtau))
 
     result .= zero(eltype(result))
     N = size(result, 1)

--- a/src/models/HubbardAttractive/HubbardModelAttractive.jl
+++ b/src/models/HubbardAttractive/HubbardModelAttractive.jl
@@ -107,11 +107,37 @@ and store it in `result::Matrix`.
 
 This is a performance critical method.
 """
+# @inline function interaction_matrix_exp!(mc::DQMC, m::HubbardModelAttractive,
+#             result::Matrix, conf::HubbardConf, slice::Int, power::Float64=1.)
+#     dtau = mc.p.delta_tau
+#     lambda = acosh(exp(m.U * dtau/2))
+#     result .= spdiagm(0 => exp.(sign(power) * lambda * conf[:,slice]))
+#     nothing
+# end
+
 @inline function interaction_matrix_exp!(mc::DQMC, m::HubbardModelAttractive,
             result::Matrix, conf::HubbardConf, slice::Int, power::Float64=1.)
-    dtau = mc.p.delta_tau
-    lambda = acosh(exp(m.U * dtau/2))
-    result .= spdiagm(0 => exp.(sign(power) * lambda * conf[:,slice]))
+
+    @timeit to "interaction_matrix_exp! old" begin
+        dtau = mc.p.delta_tau
+        lambda = acosh(exp(m.U * dtau/2))
+        result .= spdiagm(0 => exp.(sign(power) * lambda * conf[:,slice]))
+    end
+
+    temp = deepcopy(result)
+
+    @timeit to "interaction_matrix_exp! new" begin
+        dtau = mc.p.delta_tau
+        lambda = acosh(exp(0.5m.U * dtau))
+
+        result .= zero(eltype(result))
+        N = size(result, 1)
+        @inbounds for i in 1:N
+            result[i, i] = exp(sign(power) * lambda * conf[i, slice])
+        end
+    end
+
+    @assert temp ≈ result
     nothing
 end
 


### PR DESCRIPTION
Using the first commit: (w/ TimerOutputs.jl)
```julia
julia> model = HubbardModelAttractive(L=5, t=1.0, U=0.8, dims=2)
julia> dqmc = DQMC(model, beta=1.0)
julia> run!(dqmc, thermalization=1000, sweeps=1000)
julia> MonteCarlo.to
 ────────────────────────────────────────────────────────────────────────────────────────
                                                 Time                   Allocations      
                                         ──────────────────────   ───────────────────────
            Tot / % measured:                 38.5s / 15.5%           11.8GiB / 74.4%    

 Section                         ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────────────
 run!                                 1    5.99s   100%   5.99s   8.78GiB  100%   8.78GiB
   interaction_matrix_exp! old     116k    617ms  10.3%  5.32μs    419MiB  4.66%  3.70KiB
   interaction_matrix_exp! new     116k   33.2ms  0.55%   286ns     0.00B  0.00%    0.00B
 ────────────────────────────────────────────────────────────────────────────────────────
```

The calculation of `lambda` is about 25ns on my machine, so not very relevant for larger systems. Another improvement can be made by only overwriting the diagonal entries, but I'm not sure if that's save to do. Using a `Diagonal` matrix as the target is also slightly faster. 

See ![here](https://gist.github.com/ffreyer/5322772e09456399500de61ed45a0c04) for some independent benchmarks.

