### PR TITLE
Benchmarking

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StableDQMC = "0827807b-44c9-51d0-af97-efe667fe6b2a"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
 JLD = "0.9"

--- a/Project.toml
+++ b/Project.toml
@@ -27,6 +27,7 @@ Parameters = "0.12"
 Reexport = "0.2"
 Requires = "0.5, 1.0"
 StableDQMC = "0.1"
+TimerOutputs = "0.5.3"
 julia = "1"
 
 [extras]

--- a/src/Measurements.jl
+++ b/src/Measurements.jl
@@ -106,7 +106,7 @@ struct ConfigurationMeasurement{OT <: Observable} <: AbstractMeasurement
         new{typeof(o)}(o, rate)
     end
 end
-function measure!(m::ConfigurationMeasurement, mc, model, i::Int64)
+@bm function measure!(m::ConfigurationMeasurement, mc, model, i::Int64)
     (i % m.rate == 0) && push!(m.obs, conf(mc))
     nothing
 end

--- a/src/MonteCarlo.jl
+++ b/src/MonteCarlo.jl
@@ -4,16 +4,16 @@ using Reexport
 @reexport using MonteCarloObservable
 import MonteCarloObservable.AbstractObservable
 using StableDQMC, LightXML, Parameters, Requires
-using JLD
+using JLD, TimerOutputs
 
 using Printf, SparseArrays, LinearAlgebra, Dates, Random
 
 
+include("helpers.jl")
 include("flavors/abstract.jl")
 include("models/abstract.jl")
 include("lattices/abstract.jl")
 
-include("helpers.jl")
 include("Measurements.jl")
 export measurements, observables, save_measurements!, load_measurements
 

--- a/src/MonteCarlo.jl
+++ b/src/MonteCarlo.jl
@@ -1,15 +1,16 @@
 module MonteCarlo
 
 using Reexport
-@reexport using MonteCarloObservable, TimerOutputs
+@reexport using MonteCarloObservable
 import MonteCarloObservable.AbstractObservable
 using StableDQMC, LightXML, Parameters, Requires
-using JLD
+using JLD, TimerOutputs
 
 using Printf, SparseArrays, LinearAlgebra, Dates, Random
 
 
 include("helpers.jl")
+export enable_benchmarks, disable_benchmarks
 include("flavors/abstract.jl")
 include("models/abstract.jl")
 include("lattices/abstract.jl")

--- a/src/MonteCarlo.jl
+++ b/src/MonteCarlo.jl
@@ -1,10 +1,10 @@
 module MonteCarlo
 
 using Reexport
-@reexport using MonteCarloObservable
+@reexport using MonteCarloObservable, TimerOutputs
 import MonteCarloObservable.AbstractObservable
 using StableDQMC, LightXML, Parameters, Requires
-using JLD, TimerOutputs
+using JLD
 
 using Printf, SparseArrays, LinearAlgebra, Dates, Random
 

--- a/src/flavors/DQMC/DQMC.jl
+++ b/src/flavors/DQMC/DQMC.jl
@@ -21,18 +21,18 @@ struct DQMCParameters
     thermalization::Int
     sweeps::Int
     all_checks::Bool
-    safe_mult::Int 
+    safe_mult::Int
     delta_tau::Float64
     beta::Float64
-    slices::Int 
+    slices::Int
     measure_rate::Int
 end
 
 function DQMCParameters(;global_moves::Bool = false,
                         global_rate::Int    = 5,
-                        thermalization::Int = 100, 
+                        thermalization::Int = 100,
                         sweeps::Int         = 100,
-                        all_checks::Bool    = true, 
+                        all_checks::Bool    = true,
                         safe_mult::Int      = 10,
                         measure_rate::Int   = 10,
                         warn_round::Bool    = true,
@@ -58,10 +58,10 @@ function DQMCParameters(;global_moves::Bool = false,
                    thermalization,
                    sweeps,
                    all_checks,
-                   safe_mult, 
+                   safe_mult,
                    delta_tau,
                    beta,
-                   slices, 
+                   slices,
                    measure_rate)
 end
 
@@ -201,7 +201,7 @@ end
 Runs the given Monte Carlo simulation `mc`.
 Progress will be printed to `stdout` if `verbose=true` (default).
 """
-function run!(mc::DQMC; verbose::Bool=true, sweeps::Int=mc.p.sweeps,
+@bm function run!(mc::DQMC; verbose::Bool=true, sweeps::Int=mc.p.sweeps,
         thermalization=mc.p.thermalization)
 
     do_th_measurements = !isempty(mc.thermalization_measurements)
@@ -307,7 +307,7 @@ end
 Performs a sweep of local moves along spatial dimension at current
 imaginary time slice.
 """
-function sweep_spatial(mc::DQMC)
+@bm function sweep_spatial(mc::DQMC)
     m = model(mc)
     N = nsites(m)
 

--- a/src/flavors/DQMC/measurements.jl
+++ b/src/flavors/DQMC/measurements.jl
@@ -15,7 +15,7 @@ function GreensMeasurement(mc::DQMC, model)
     )
     GreensMeasurement{typeof(o)}(o)
 end
-function measure!(m::GreensMeasurement, mc::DQMC, model, i::Int64)
+@bm function measure!(m::GreensMeasurement, mc::DQMC, model, i::Int64)
     push!(m.obs, greens(mc))
 end
 
@@ -36,7 +36,7 @@ function BosonEnergyMeasurement(mc::DQMC, model)
     o = LightObservable(Float64, name="Bosonic Energy", alloc=1_000_000)
     BosonEnergyMeasurement{typeof(o)}(o)
 end
-function measure!(m::BosonEnergyMeasurement, mc::DQMC, model, i::Int64)
+@bm function measure!(m::BosonEnergyMeasurement, mc::DQMC, model, i::Int64)
     push!(m.obs, energy_boson(mc, model, conf(mc)))
 end
 

--- a/src/flavors/DQMC/slice_matrices.jl
+++ b/src/flavors/DQMC/slice_matrices.jl
@@ -7,7 +7,7 @@ const DQMC_CBFalse = DQMC{M, CheckerboardFalse} where M
 Direct calculation of effective slice matrix, i.e. no checkerboard.
 Calculates `Beff(slice) = exp(−1/2∆tauT)exp(−1/2∆tauT)exp(−∆tauV(slice))`.
 """
-function slice_matrix(mc::DQMC_CBFalse, m::Model, slice::Int, power::Float64=1.)
+@bm function slice_matrix(mc::DQMC_CBFalse, m::Model, slice::Int, power::Float64=1.)
     eT = mc.s.hopping_matrix_exp
     eTinv = mc.s.hopping_matrix_exp_inv
     eV = mc.s.eV
@@ -20,7 +20,7 @@ function slice_matrix(mc::DQMC_CBFalse, m::Model, slice::Int, power::Float64=1.)
         return eV * eTinv * eTinv
     end
 end
-function slice_matrix!(mc::DQMC_CBFalse, m::Model, slice::Int,
+@bm function slice_matrix!(mc::DQMC_CBFalse, m::Model, slice::Int,
                     power::Float64=1., result = mc.s.U)
     eT = mc.s.hopping_matrix_exp
     eTinv = mc.s.hopping_matrix_exp_inv
@@ -41,35 +41,35 @@ function slice_matrix!(mc::DQMC_CBFalse, m::Model, slice::Int,
 end
 
 
-function multiply_slice_matrix_left!(mc::DQMC_CBFalse, m::Model,
+@bm function multiply_slice_matrix_left!(mc::DQMC_CBFalse, m::Model,
                                 slice::Int, M::AbstractMatrix)
     slice_matrix!(mc, m, slice, 1.0, mc.s.U)
     mul!(mc.s.tmp, mc.s.U, M)
     M .= mc.s.tmp
     nothing
 end
-function multiply_slice_matrix_right!(mc::DQMC_CBFalse, m::Model,
+@bm function multiply_slice_matrix_right!(mc::DQMC_CBFalse, m::Model,
                                 slice::Int, M::AbstractMatrix)
     slice_matrix!(mc, m, slice, 1.0, mc.s.U)
     mul!(mc.s.tmp, M, mc.s.U)
     M .= mc.s.tmp
     nothing
 end
-function multiply_slice_matrix_inv_right!(mc::DQMC_CBFalse, m::Model,
+@bm function multiply_slice_matrix_inv_right!(mc::DQMC_CBFalse, m::Model,
                                 slice::Int, M::AbstractMatrix)
     slice_matrix!(mc, m, slice, -1.0, mc.s.U)
     mul!(mc.s.tmp, M, mc.s.U)
     M .= mc.s.tmp
     nothing
 end
-function multiply_slice_matrix_inv_left!(mc::DQMC_CBFalse, m::Model,
+@bm function multiply_slice_matrix_inv_left!(mc::DQMC_CBFalse, m::Model,
                                 slice::Int, M::AbstractMatrix)
     slice_matrix!(mc, m, slice, -1.0, mc.s.U)
     mul!(mc.s.tmp, mc.s.U, M)
     M .= mc.s.tmp
     nothing
 end
-function multiply_daggered_slice_matrix_left!(mc::DQMC_CBFalse, m::Model,
+@bm function multiply_daggered_slice_matrix_left!(mc::DQMC_CBFalse, m::Model,
                                 slice::Int, M::AbstractMatrix)
     slice_matrix!(mc, m, slice, 1.0, mc.s.U)
     mul!(mc.s.tmp, adjoint(mc.s.U), M)
@@ -81,7 +81,7 @@ end
 # CheckerboardTrue
 const DQMC_CBTrue = DQMC{M, CheckerboardTrue} where M
 
-function slice_matrix(mc::DQMC_CBTrue, m::Model, slice::Int,
+@bm function slice_matrix(mc::DQMC_CBTrue, m::Model, slice::Int,
                     power::Float64=1.)
     M = Matrix{heltype(mc)}(I, m.flv*m.l.sites, m.flv*m.l.sites)
     if power > 0
@@ -91,7 +91,7 @@ function slice_matrix(mc::DQMC_CBTrue, m::Model, slice::Int,
     end
     return M
 end
-function slice_matrix!(mc::DQMC_CBTrue, m::Model, slice::Int,
+@bm function slice_matrix!(mc::DQMC_CBTrue, m::Model, slice::Int,
                     power::Float64=1., M = mc.s.U)
     copyto!(M, I)
     if power > 0
@@ -102,7 +102,7 @@ function slice_matrix!(mc::DQMC_CBTrue, m::Model, slice::Int,
     return M
 end
 
-function multiply_slice_matrix_left!(mc::DQMC_CBTrue, m::Model, slice::Int,
+@bm function multiply_slice_matrix_left!(mc::DQMC_CBTrue, m::Model, slice::Int,
                     M::AbstractMatrix{T}) where T<:Number
     s = mc.s
     interaction_matrix_exp!(mc, m, s.eV, mc.conf, slice, 1.)
@@ -126,7 +126,7 @@ function multiply_slice_matrix_left!(mc::DQMC_CBTrue, m::Model, slice::Int,
     end
     nothing
 end
-function multiply_slice_matrix_right!(mc::DQMC_CBTrue, m::Model, slice::Int,
+@bm function multiply_slice_matrix_right!(mc::DQMC_CBTrue, m::Model, slice::Int,
                     M::AbstractMatrix{T}) where T<:Number
     s = mc.s
     @inbounds begin
@@ -149,7 +149,7 @@ function multiply_slice_matrix_right!(mc::DQMC_CBTrue, m::Model, slice::Int,
     M .= s.tmp
     nothing
 end
-function multiply_slice_matrix_inv_left!(mc::DQMC_CBTrue, m::Model, slice::Int,
+@bm function multiply_slice_matrix_inv_left!(mc::DQMC_CBTrue, m::Model, slice::Int,
                     M::AbstractMatrix{T}) where T<:Number
     s = mc.s
     @inbounds begin
@@ -172,7 +172,7 @@ function multiply_slice_matrix_inv_left!(mc::DQMC_CBTrue, m::Model, slice::Int,
     M .= s.tmp
     nothing
 end
-function multiply_slice_matrix_inv_right!(mc::DQMC_CBTrue, m::Model, slice::Int,
+@bm function multiply_slice_matrix_inv_right!(mc::DQMC_CBTrue, m::Model, slice::Int,
                     M::AbstractMatrix{T}) where T<:Number
     s = mc.s
     interaction_matrix_exp!(mc, m, s.eV, mc.conf, slice, -1.)
@@ -196,7 +196,7 @@ function multiply_slice_matrix_inv_right!(mc::DQMC_CBTrue, m::Model, slice::Int,
     end
     nothing
 end
-function multiply_daggered_slice_matrix_left!(mc::DQMC_CBTrue, m::Model, slice::Int,
+@bm function multiply_daggered_slice_matrix_left!(mc::DQMC_CBTrue, m::Model, slice::Int,
                     M::AbstractMatrix{T}) where T<:Number
     s = mc.s
 

--- a/src/flavors/DQMC/stack.jl
+++ b/src/flavors/DQMC/stack.jl
@@ -230,7 +230,7 @@ end
 """
 Updates stack[idx+1] based on stack[idx]
 """
-function add_slice_sequence_left(mc::DQMC, idx::Int)
+@bm function add_slice_sequence_left(mc::DQMC, idx::Int)
     copyto!(mc.s.curr_U, mc.s.u_stack[:, :, idx])
 
     # println("Adding slice seq left $idx = ", mc.s.ranges[idx])
@@ -245,7 +245,7 @@ end
 """
 Updates stack[idx] based on stack[idx+1]
 """
-function add_slice_sequence_right(mc::DQMC, idx::Int)
+@bm function add_slice_sequence_right(mc::DQMC, idx::Int)
     copyto!(mc.s.curr_U, mc.s.u_stack[:, :, idx + 1])
 
     for slice in reverse(mc.s.ranges[idx])
@@ -262,7 +262,7 @@ end
 Calculates G(slice) using mc.s.Ur,mc.s.Dr,mc.s.Tr=B(slice)' ... B(M)' and
 mc.s.Ul,mc.s.Dl,mc.s.Tl=B(slice-1) ... B(1)
 """
-function calculate_greens(mc::DQMC)
+@bm function calculate_greens(mc::DQMC)
     # U, D, T = udt(mc.s.greens) after this
     mc.s.U, mc.s.D, mc.s.T = udt_inv_one_plus(
         UDT(mc.s.Ul, mc.s.Dl, mc.s.Tl),
@@ -278,7 +278,7 @@ end
 """
 Only reasonable immediately after calculate_greens()!
 """
-function calculate_logdet(mc::DQMC)
+@bm function calculate_logdet(mc::DQMC)
     mc.s.log_det = real(
         log(complex(det(mc.s.U))) +
         sum(log.(mc.s.D)) +
@@ -288,7 +288,7 @@ function calculate_logdet(mc::DQMC)
 end
 
 # Green's function propagation
-@inline function wrap_greens!(mc::DQMC, gf::Matrix, curr_slice::Int, direction::Int)
+@inline @bm function wrap_greens!(mc::DQMC, gf::Matrix, curr_slice::Int, direction::Int)
     if direction == -1
         multiply_slice_matrix_inv_left!(mc, mc.model, curr_slice - 1, gf)
         multiply_slice_matrix_right!(mc, mc.model, curr_slice - 1, gf)
@@ -303,7 +303,7 @@ end
 #     wrap_greens!(mc, temp, slice, direction)
 #     return temp
 # end
-function propagate(mc::DQMC)
+@bm function propagate(mc::DQMC)
     if mc.s.direction == 1
         if mod(mc.s.current_slice, mc.p.safe_mult) == 0
             mc.s.current_slice +=1 # slice we are going to

--- a/src/flavors/MC/MC.jl
+++ b/src/flavors/MC/MC.jl
@@ -141,7 +141,7 @@ end
 Runs the given Monte Carlo simulation `mc`.
 Progress will be printed to `stdout` if `verbose=true` (default).
 """
-function run!(mc::MC; verbose::Bool=true, sweeps::Int=mc.p.sweeps,
+@bm function run!(mc::MC; verbose::Bool=true, sweeps::Int=mc.p.sweeps,
         thermalization=mc.p.thermalization)
 
     do_th_measurements = !isempty(mc.thermalization_measurements)
@@ -216,7 +216,7 @@ end
 
 Performs a sweep of local moves.
 """
-@inline function sweep(mc::MC)
+@inline @bm function sweep(mc::MC)
     c = conf(mc)
     m = model(mc)
     β = beta(mc)

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -104,8 +104,8 @@ end
 Wraps the body of a function with `@timeit_debug <function name> begin ... end`.
 
 The `@timeit_debug` macro can be disabled. When it is, it should come with zero
-overhead. To enable timing, use `<module>.timeit_debug_enabled()`. See
-TimerOutputs.jl for more details.
+overhead. To enable timing, use `TimerOutputs.enable_debug_timings(<module>)`.
+See TimerOutputs.jl for more details.
 
 Benchmarks/Timings can be retrieved using `print_timer()` and reset with
 `reset_timer!()`. It should be no problem to add additonal `@timeit_debug` to
@@ -122,3 +122,5 @@ macro bm(func)
         end
     ))
 end
+
+timeit_debug_enabled() = false

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -112,7 +112,7 @@ Benchmarks/Timings can be retrieved using `print_timer()` and reset with
 a function.
 """
 macro bm(func)
-    Expr(
+    esc(Expr(
         func.head,     # function or =
         func.args[1],  # function name w/ args
         quote                                  # name of function
@@ -120,5 +120,5 @@ macro bm(func)
                 $(func.args[2]) # function body
             end
         end
-    )
+    ))
 end

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -95,3 +95,30 @@ function SparseArrays.mul!(C::StridedMatrix, X::StridedMatrix, A::SparseMatrixCS
     end
     C
 end
+
+
+"""
+    @bm function ... end
+    @bm foo(args...) = ...
+
+Wraps the body of a function with `@timeit_debug <function name> begin ... end`.
+
+The `@timeit_debug` macro can be disabled. When it is, it should come with zero
+overhead. To enable timing, use `<module>.timeit_debug_enabled()`. See
+TimerOutputs.jl for more details.
+
+Benchmarks/Timings can be retrieved using `print_timer()` and reset with
+`reset_timer!()`. It should be no problem to add additonal `@timeit_debug` to
+a function.
+"""
+macro bm(func)
+    Expr(
+        func.head,     # function or =
+        func.args[1],  # function name w/ args
+        quote                                  # name of function
+            MonteCarlo.@timeit_debug $(string(func.args[1].args[1])) begin
+                $(func.args[2]) # function body
+            end
+        end
+    )
+end

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -124,3 +124,29 @@ macro bm(func)
 end
 
 timeit_debug_enabled() = false
+
+"""
+    enable_benchmarks()
+
+Enables benchmarking for `MonteCarlo`.
+
+This affects every function with the `MonteCarlo.@bm` macro as well as any
+`TimerOutputs.@timeit_debug` blocks. Benchmarks are recorded to the default
+TimerOutput `TimerOutputs.DEFAULT_TIMER`. Results can be printed via
+`TimerOutputs.print_timer()`.
+
+[`disable_benchmarks`](@ref)
+"""
+enable_benchmarks() = TimerOutputs.enable_debug_timings(MonteCarlo)
+
+"""
+    disable_benchmarks()
+
+Disables benchmarking for `MonteCarlo`.
+
+This affects every function with the `MonteCarlo.@bm` macro as well as any
+`TimerOutputs.@timeit_debug` blocks.
+
+[`enable_benchmarks`](@ref)
+"""
+disable_benchmarks() = TimerOutputs.disable_debug_timings(MonteCarlo)

--- a/src/models/HubbardAttractive/HubbardModelAttractive.jl
+++ b/src/models/HubbardAttractive/HubbardModelAttractive.jl
@@ -107,7 +107,7 @@ and store it in `result::Matrix`.
 
 This is a performance critical method.
 """
-@inline function interaction_matrix_exp!(mc::DQMC, m::HubbardModelAttractive,
+@inline @bm function interaction_matrix_exp!(mc::DQMC, m::HubbardModelAttractive,
             result::Matrix, conf::HubbardConf, slice::Int, power::Float64=1.)
     dtau = mc.p.delta_tau
     lambda = acosh(exp(m.U * dtau/2))
@@ -116,7 +116,7 @@ This is a performance critical method.
 end
 
 
-@inline function propose_local(mc::DQMC, m::HubbardModelAttractive, i::Int, slice::Int, conf::HubbardConf)
+@inline @bm function propose_local(mc::DQMC, m::HubbardModelAttractive, i::Int, slice::Int, conf::HubbardConf)
     # see for example dos Santos (2002)
     greens = mc.s.greens
     dtau = mc.p.delta_tau
@@ -129,7 +129,7 @@ end
     return detratio, ΔE_boson, γ
 end
 
-@inline function accept_local!(mc::DQMC, m::HubbardModelAttractive, i::Int, slice::Int, conf::HubbardConf, delta, detratio, ΔE_boson::Float64)
+@inline @bm function accept_local!(mc::DQMC, m::HubbardModelAttractive, i::Int, slice::Int, conf::HubbardConf, delta, detratio, ΔE_boson::Float64)
     greens = mc.s.greens
     γ = delta
 

--- a/src/models/Ising/IsingModel.jl
+++ b/src/models/Ising/IsingModel.jl
@@ -65,7 +65,7 @@ Base.show(io::IO, m::MIME"text/plain", model::IsingModel) = print(io, model)
 # implement `MC` interface
 Base.rand(::Type{MC}, m::IsingModel) = rand(IsingDistribution, fill(m.L, ndims(m))...)
 
-@propagate_inbounds function propose_local(mc::MC, m::IsingModel, i::Int, conf::IsingConf)
+@propagate_inbounds @bm function propose_local(mc::MC, m::IsingModel, i::Int, conf::IsingConf)
     field = 0.0
     @inbounds for nb in 1:size(m.neighs, 1)
         field += conf[m.neighs[nb, i]]
@@ -74,14 +74,14 @@ Base.rand(::Type{MC}, m::IsingModel) = rand(IsingDistribution, fill(m.L, ndims(m
     return delta_E, nothing
 end
 
-@propagate_inbounds function accept_local!(mc::MC, m::IsingModel, i::Int, conf::IsingConf, delta_i, delta_E::Float64)
+@propagate_inbounds @bm function accept_local!(mc::MC, m::IsingModel, i::Int, conf::IsingConf, delta_i, delta_E::Float64)
     m.energy[] += delta_E
     conf[i] *= -1
     nothing
 end
 
 # optimized for 2D case
-@propagate_inbounds function propose_local(mc::MC, m::IsingModel{SquareLattice}, i::Int, conf::IsingConf)
+@propagate_inbounds @bm function propose_local(mc::MC, m::IsingModel{SquareLattice}, i::Int, conf::IsingConf)
     neighs = m.neighs
     @inbounds delta_E = 2. * conf[i] * (conf[neighs[1, i]] + conf[neighs[2, i]] +
                               + conf[neighs[3, i]] + conf[neighs[4, i]])
@@ -96,7 +96,7 @@ end
 Constructs a Wolff cluster spinflip for configuration `conf`.
 Returns wether a cluster spinflip has been performed (any spins have been flipped).
 """
-function global_move(mc::MC, m::IsingModel, conf::IsingConf)
+@bm function global_move(mc::MC, m::IsingModel, conf::IsingConf)
     N = nsites(m)
     neighs = m.neighs
     beta = mc.p.beta

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,14 +17,14 @@ using MonteCarlo: @bm, TimerOutputs
 
         TimerOutputs.enable_debug_timings(Main)
         x, y = 0.005, 0.005
-        MonteCarlo.test1(x, y)
-        MonteCarlo.test2(x, y)
+        test1(x, y)
+        test2(x, y)
         test3(x, y)
         test4(x, y)
         TimerOutputs.reset_timer!()
         for _ in 1:10
-            MonteCarlo.test1(x, y)
-            MonteCarlo.test2(x, y)
+            test1(x, y)
+            test2(x, y)
             test3(x, y)
             test4(x, y)
         end
@@ -39,6 +39,7 @@ using MonteCarlo: @bm, TimerOutputs
         @test t1 ≈ t2 rtol=0.01
         @test t2 ≈ t3 rtol=0.01
         @test t3 ≈ t4 rtol=0.01
+        TimerOutputs.reset_timer!()
     end
 
     @testset "Lattices" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,12 @@ using MonteCarlo: @bm, TimerOutputs
         x = code_lowered(test2, Tuple{Float64, Float64})[1]
         y = code_lowered(test4, Tuple{Float64, Float64})[1]
         @test x.code == y.code
+
+        @test !MonteCarlo.timeit_debug_enabled()
+        enable_benchmarks()
+        @test MonteCarlo.timeit_debug_enabled()
+        disable_benchmarks()
+        @test !MonteCarlo.timeit_debug_enabled()
     end
 
     @testset "Lattices" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,46 @@
 using MonteCarlo, MonteCarloObservable
 using Test
 using Random
+using MonteCarlo: @bm, TimerOutputs
+
 
 @testset "All Tests" begin
+    @testset "Utilities" begin
+        @bm function test1(x, y)
+            sleep(x+y)
+        end
+        @bm test2(x, y) = sleep(x+y)
+        function test3(x, y)
+            TimerOutputs.@timeit_debug "test3" begin sleep(x+y) end
+        end
+        test4(x, y) = TimerOutputs.@timeit_debug "test4" begin sleep(x+y) end
+
+        TimerOutputs.enable_debug_timings(Main)
+        x, y = 0.005, 0.005
+        MonteCarlo.test1(x, y)
+        MonteCarlo.test2(x, y)
+        test3(x, y)
+        test4(x, y)
+        TimerOutputs.reset_timer!()
+        for _ in 1:10
+            MonteCarlo.test1(x, y)
+            MonteCarlo.test2(x, y)
+            test3(x, y)
+            test4(x, y)
+        end
+        TimerOutputs.disable_debug_timings(Main)
+
+        to = TimerOutputs.DEFAULT_TIMER
+        t1 = TimerOutputs.time(to["test1"])
+        t2 = TimerOutputs.time(to["test2"])
+        t3 = TimerOutputs.time(to["test3"])
+        t4 = TimerOutputs.time(to["test4"])
+
+        @test t1 ≈ t2 rtol=0.01
+        @test t2 ≈ t3 rtol=0.01
+        @test t3 ≈ t4 rtol=0.01
+    end
+
     @testset "Lattices" begin
         include("lattices.jl")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,35 +11,25 @@ using MonteCarlo: @bm, TimerOutputs
         end
         @bm test2(x, y) = sleep(x+y)
         function test3(x, y)
-            TimerOutputs.@timeit_debug "test3" begin sleep(x+y) end
+            TimerOutputs.@timeit_debug "test1" begin sleep(x+y) end
         end
-        test4(x, y) = TimerOutputs.@timeit_debug "test4" begin sleep(x+y) end
+        test4(x, y) = TimerOutputs.@timeit_debug "test2" begin sleep(x+y) end
 
-        TimerOutputs.enable_debug_timings(Main)
-        x, y = 0.005, 0.005
-        test1(x, y)
-        test2(x, y)
-        test3(x, y)
-        test4(x, y)
-        TimerOutputs.reset_timer!()
-        for _ in 1:10
-            test1(x, y)
-            test2(x, y)
-            test3(x, y)
-            test4(x, y)
-        end
-        TimerOutputs.disable_debug_timings(Main)
+        x = code_lowered(test1, Tuple{Float64, Float64})[1]
+        y = code_lowered(test3, Tuple{Float64, Float64})[1]
+        println(x.code)
+        println()
+        println(y.code)
+        println()
+        @test x.code == y.code
 
-        to = TimerOutputs.DEFAULT_TIMER
-        t1 = TimerOutputs.time(to["test1"])
-        t2 = TimerOutputs.time(to["test2"])
-        t3 = TimerOutputs.time(to["test3"])
-        t4 = TimerOutputs.time(to["test4"])
-
-        @test t1 ≈ t2 rtol=0.01
-        @test t2 ≈ t3 rtol=0.01
-        @test t3 ≈ t4 rtol=0.01
-        TimerOutputs.reset_timer!()
+        x = code_lowered(test2, Tuple{Float64, Float64})[1]
+        y = code_lowered(test4, Tuple{Float64, Float64})[1]
+        println(x.code)
+        println()
+        println(y.code)
+        println()
+        @test x.code == y.code
     end
 
     @testset "Lattices" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,18 +17,10 @@ using MonteCarlo: @bm, TimerOutputs
 
         x = code_lowered(test1, Tuple{Float64, Float64})[1]
         y = code_lowered(test3, Tuple{Float64, Float64})[1]
-        println(x.code)
-        println()
-        println(y.code)
-        println()
         @test x.code == y.code
 
         x = code_lowered(test2, Tuple{Float64, Float64})[1]
         y = code_lowered(test4, Tuple{Float64, Float64})[1]
-        println(x.code)
-        println()
-        println(y.code)
-        println()
         @test x.code == y.code
     end
 


### PR DESCRIPTION
I added a macro `@bm` which wraps the body of a function in `@timeit_debug <name of function> begin ... end`. Imo this is nicer than writing `@timeit_debug` in every function. It's also easier/faster to do.

I think it would be fine to tag functions with `@bm` in master, since `@timeit_debug` should be optimized away when benchmarks are disabled and because it is relatively little noise. Thoughts?