### PR TITLE
Fix benchmarking scope

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,9 @@ using Test
 using Random
 using MonteCarlo: @bm, TimerOutputs
 
+macro benchmark_test(name, code)
+    TimerOutputs.timer_expr(MonteCarlo, true, name, code)
+end
 
 @testset "All Tests" begin
     @testset "Utilities" begin
@@ -10,10 +13,12 @@ using MonteCarlo: @bm, TimerOutputs
             sleep(x+y)
         end
         @bm test2(x, y) = sleep(x+y)
+        # @eval MonteCarlo ... will put the body of test3, test4 in the wrong scope
+        # eval(timer_expr(...)) doesn't work
         function test3(x, y)
-            TimerOutputs.@timeit_debug "test1" begin sleep(x+y) end
+            @benchmark_test "test1" begin sleep(x+y) end
         end
-        test4(x, y) = TimerOutputs.@timeit_debug "test2" begin sleep(x+y) end
+        test4(x, y) = @benchmark_test "test2" begin sleep(x+y) end
 
         x = code_lowered(test1, Tuple{Float64, Float64})[1]
         y = code_lowered(test3, Tuple{Float64, Float64})[1]
@@ -56,3 +61,27 @@ using MonteCarlo: @bm, TimerOutputs
         include("ED/ED_tests.jl")
     end
 end
+
+using MonteCarlo
+using MonteCarlo: @bm
+using TimerOutputs
+@bm function test1(x, y)
+    sleep(x+y)
+end
+@bm test2(x, y) = sleep(x+y)
+macro benchmark_test(name, code)
+    TimerOutputs.timer_expr(MonteCarlo, true, name, code)
+end
+function test3(x, y)
+    @benchmark_test "test1" begin sleep(x+y) end
+end
+test4(x, y) = @benchmark_test "test2" begin sleep(x+y) end
+
+
+x = code_lowered(test1, Tuple{Float64, Float64})[1]
+y = code_lowered(test3, Tuple{Float64, Float64})[1]
+@test x.code == y.code
+
+x = code_lowered(test2, Tuple{Float64, Float64})[1]
+y = code_lowered(test4, Tuple{Float64, Float64})[1]
+@test x.code == y.code


### PR DESCRIPTION
The `@bm` macro has a slight problem - it uses the `timeit_debug_enabled()` from whichever scope it is called from.

For example (assuming the following is not defined in a module)
```julia
using MonteCarlo: @bm

# This requires Main.timeit_debug_enabled() = true
@bm foo() = 1

# This requires A.timeit_debug_enabled() = true
module A
@bm bar() = 1
end
```

This change makes it so that any use of `@bm` connects to `MonteCarlo.timeit_debug_enabled()`. The benchmarked code is still evaluated in the outer scope, so functions defined in `Main` should be callable and unexported functions from MonteCarlo should not be (without the module prefix).

This also adds the ability to use `@bm` like `@timeit_debug`, i.e. `@bm "name" begin ... end`.