### PR TITLE
Generic stack matrices (optimizations)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]

--- a/src/MonteCarlo.jl
+++ b/src/MonteCarlo.jl
@@ -19,7 +19,7 @@ include("helpers.jl")
 export enable_benchmarks, disable_benchmarks, print_timer, reset_timer!
 include("linalg/general.jl")
 include("linalg/UDT.jl")
-include("linalg/complex.jl")
+# include("linalg/complex.jl") # TODO
 include("linalg/blockdiagonal.jl")
 include("flavors/abstract.jl")
 include("models/abstract.jl")

--- a/src/MonteCarlo.jl
+++ b/src/MonteCarlo.jl
@@ -20,6 +20,7 @@ export enable_benchmarks, disable_benchmarks, print_timer, reset_timer!
 include("linalg/general.jl")
 include("linalg/UDT.jl")
 include("linalg/complex.jl")
+include("linalg/blockdiagonal.jl")
 include("flavors/abstract.jl")
 include("models/abstract.jl")
 include("lattices/abstract.jl")

--- a/src/MonteCarlo.jl
+++ b/src/MonteCarlo.jl
@@ -19,6 +19,7 @@ include("helpers.jl")
 export enable_benchmarks, disable_benchmarks, print_timer, reset_timer!
 include("linalg/general.jl")
 include("linalg/UDT.jl")
+include("linalg/complex.jl")
 include("flavors/abstract.jl")
 include("models/abstract.jl")
 include("lattices/abstract.jl")

--- a/src/MonteCarlo.jl
+++ b/src/MonteCarlo.jl
@@ -16,8 +16,9 @@ const JLDFile = Union{JLD.JldFile, JLD2.JLDFile}
 
 
 include("helpers.jl")
-include("inplace_udt.jl")
 export enable_benchmarks, disable_benchmarks, print_timer, reset_timer!
+include("linalg/general.jl")
+include("linalg/UDT.jl")
 include("flavors/abstract.jl")
 include("models/abstract.jl")
 include("lattices/abstract.jl")

--- a/src/MonteCarlo.jl
+++ b/src/MonteCarlo.jl
@@ -5,7 +5,7 @@ using Reexport
 @reexport using MonteCarloObservable, Random
 import MonteCarloObservable.AbstractObservable
 using Parameters, Requires
-using TimerOutputs, LoopVectorization
+using TimerOutputs, LoopVectorization, StructArrays
 using Printf, SparseArrays, LinearAlgebra, Dates, Statistics
 
 import JLD, JLD2

--- a/src/flavors/DQMC/DQMC.jl
+++ b/src/flavors/DQMC/DQMC.jl
@@ -147,6 +147,9 @@ mutable struct DQMC{
         }
         complete!(new{M, CB, ConfType, RT, Stack}(), kwargs)
     end
+    function DQMC(CB::Type{<:Checkerboard}; kwargs...)
+        DQMC{Model, CB, Any, AbstractRecorder, AbstractDQMCStack}(; kwargs...)
+    end
     function DQMC{CB}(
             model::M,
             conf::ConfType,
@@ -168,6 +171,7 @@ mutable struct DQMC{
     end
     DQMC{M, CB, C, RT, S}(args...) where {M, CB, C, RT, S} = DQMC{CB}(args...)
 end
+
 
 function complete!(a::DQMC, kwargs)
     for (field, val) in kwargs
@@ -794,7 +798,9 @@ function _load(data, ::Type{T}) where T <: DQMC
         throw(ErrorException("Failed to load $T version $(data["VERSION"])"))
     end
 
-    mc = data["type"]()
+    CB = data["type"].parameters[2]
+    @assert CB <: Checkerboard
+    mc = DQMC(CB)
     mc.p = _load(data["Parameters"], data["Parameters"]["type"])
     mc.a = _load(data["Analysis"], data["Analysis"]["type"])
     mc.conf = data["conf"]

--- a/src/flavors/DQMC/DQMC.jl
+++ b/src/flavors/DQMC/DQMC.jl
@@ -729,8 +729,8 @@ exponentials from left and right.
 """
 @bm greens(mc::DQMC) = _greens!(mc)
 function _greens!(
-        mc::DQMC_CBFalse, target::Matrix = mc.s.Ul, 
-        source::Matrix = mc.s.greens, temp::Matrix = mc.s.Ur
+        mc::DQMC_CBFalse, target::AbstractMatrix = mc.s.Ul, 
+        source::AbstractMatrix = mc.s.greens, temp::AbstractMatrix = mc.s.Ur
     )
     eThalfminus = mc.s.hopping_matrix_exp
     eThalfplus = mc.s.hopping_matrix_exp_inv
@@ -739,8 +739,8 @@ function _greens!(
     return target
 end
 function _greens!(
-        mc::DQMC_CBTrue, target::Matrix = mc.s.Ul, 
-        source::Matrix = mc.s.greens, temp::Matrix = mc.s.Ur
+        mc::DQMC_CBTrue, target::AbstractMatrix = mc.s.Ul, 
+        source::AbstractMatrix = mc.s.greens, temp::AbstractMatrix = mc.s.Ur
     )
     chkr_hop_half_minus = mc.s.chkr_hop_half
     chkr_hop_half_plus = mc.s.chkr_hop_half_inv

--- a/src/flavors/DQMC/DQMC_mandatory.jl
+++ b/src/flavors/DQMC/DQMC_mandatory.jl
@@ -43,7 +43,7 @@ part of the `hopping_matrix` and not the interaction.
 
 This is a performance critical method and one might consider efficient in-place (in `result`) construction.
 """
-interaction_matrix_exp!(mc::DQMC, m::Model, result::Matrix, conf, slice::Int, power::Float64=1.) = 
+interaction_matrix_exp!(mc::DQMC, m::Model, result, conf, slice::Int, power::Float64=1.) = 
     MethodError(interaction_matrix_exp!, (mc, m, result, conf, slice, power))
 
 

--- a/src/flavors/DQMC/DQMC_optional.jl
+++ b/src/flavors/DQMC/DQMC_optional.jl
@@ -13,6 +13,25 @@ Returns the type of the elements of the hopping matrix. Defaults to `Float64`.
 hoppingeltype(::Type{DQMC}, m::Model) = Float64
 
 """
+    interaction_matrix_type(T::Type{DQMC}, m::Model)
+
+Returns the (matrix) type of the interaction matrix. Defaults to 
+`Matrix{greenseltype(T, m)}`.
+"""
+interaction_matrix_type(T::Type{DQMC}, m::Model) = Matrix{greenseltype(T, m)}
+
+"""
+    init_interaction_matrix(m::Model)
+
+Initializes the interaction matrix.
+"""
+function init_interaction_matrix(m::Model)
+    N = length(lattice(m))
+    flv = nflavors(m)
+    zeros(greenseltype(DQMC, m), N*flv, N*flv)
+end
+
+"""
     energy(mc::DQMC, m::Model, conf)
 
 Calculate bosonic part (non-Green's function determinant part) of energy for configuration `conf` for Model `m`.

--- a/src/flavors/DQMC/DQMC_optional.jl
+++ b/src/flavors/DQMC/DQMC_optional.jl
@@ -12,6 +12,8 @@ Returns the type of the elements of the hopping matrix. Defaults to `Float64`.
 """
 hoppingeltype(::Type{DQMC}, m::Model) = Float64
 
+
+
 """
     interaction_matrix_type(T::Type{DQMC}, m::Model)
 
@@ -19,6 +21,24 @@ Returns the (matrix) type of the interaction matrix. Defaults to
 `Matrix{greenseltype(T, m)}`.
 """
 interaction_matrix_type(T::Type{DQMC}, m::Model) = Matrix{greenseltype(T, m)}
+
+"""
+    hopping_matrix_type(T::Type{DQMC}, m::Model)
+
+Returns the (matrix) type of the hopping matrix. Defaults to 
+`Matrix{hoppingeltype(T, m)}`.
+"""
+hopping_matrix_type(T::Type{DQMC}, m::Model) = Matrix{hoppingeltype(T, m)}
+
+"""
+    greens_matrix_type(T::Type{DQMC}, m::Model)
+
+Returns the (matrix) type of the greens and most work matrices. Defaults to 
+`Matrix{greenseltype(T, m)}`.
+"""
+greens_matrix_type(T::Type{DQMC}, m::Model) = Matrix{greenseltype(T, m)}
+
+
 
 """
     init_interaction_matrix(m::Model)
@@ -30,6 +50,7 @@ function init_interaction_matrix(m::Model)
     flv = nflavors(m)
     zeros(greenseltype(DQMC, m), N*flv, N*flv)
 end
+
 
 """
     energy(mc::DQMC, m::Model, conf)

--- a/src/flavors/DQMC/stack.jl
+++ b/src/flavors/DQMC/stack.jl
@@ -7,7 +7,7 @@ mutable struct DQMCStack{
     } <: AbstractDQMCStack
 
     u_stack::Vector{GreensMatType}
-    d_stack::Vector{Vector{GreensElType}}
+    d_stack::Vector{Vector{Float64}}
     t_stack::Vector{GreensMatType}
 
     Ul::GreensMatType
@@ -334,10 +334,10 @@ Diagonal matrices), `pivot` an integer Vector and `temp` a Vector with the same
 element type as the matrices.
 """
 @bm function calculate_greens_AVX!(
-        Ul, Dl, Tl, Ur, Dr, Tr, G,
+        Ul, Dl, Tl, Ur, Dr, Tr, G::AbstractArray{T},
         pivot = Vector{Int64}(undef, length(Dl)),
-        temp = Vector{eltype(G)}(undef, length(Dl))
-    )
+        temp = Vector{T}(undef, length(Dl))
+    ) where T
     # @bm "B1" begin
         # Used: Ul, Dl, Tl, Ur, Dr, Tr
         # TODO: [I + Ul Dl Tl Tr^† Dr Ur^†]^-1
@@ -631,4 +631,3 @@ end
     end
     nothing
 end
-

--- a/src/flavors/DQMC/stack.jl
+++ b/src/flavors/DQMC/stack.jl
@@ -364,10 +364,7 @@ element type as the matrices.
     # @bm "B3" begin
         # Used: Tl, Ur, Tr, Dr
         # TODO: Ur [Tr + Dr]^-1 Tl^† -> Ur [Tr]^-1 Tl^†
-        @avx for i in 1:length(Dr)
-            # G[i, i] = G[i, i] + Dr[i]
-            Tr[i, i] = Tr[i, i] + Dr[i]
-        end
+        rvadd!(Tr, Diagonal(Dr))
     # end
 
     # @bm "B4" begin
@@ -493,7 +490,7 @@ end
 
 
 # Green's function propagation
-@inline @bm function wrap_greens!(mc::DQMC, gf::Matrix, curr_slice::Int, direction::Int)
+@inline @bm function wrap_greens!(mc::DQMC, gf, curr_slice::Int, direction::Int)
     if direction == -1
         multiply_slice_matrix_inv_left!(mc, mc.model, curr_slice - 1, gf)
         multiply_slice_matrix_right!(mc, mc.model, curr_slice - 1, gf)

--- a/src/flavors/DQMC/stack.jl
+++ b/src/flavors/DQMC/stack.jl
@@ -1,5 +1,8 @@
-# type
-mutable struct DQMCStack{GreensEltype<:Number, HoppingEltype<:Number} <: AbstractDQMCStack
+mutable struct DQMCStack{
+        GreensEltype <: Number, 
+        HoppingEltype <: Number,
+        InteractionMatType <: AbstractArray
+    } <: AbstractDQMCStack
     u_stack::Array{GreensEltype, 3}
     d_stack::Matrix{Float64}
     t_stack::Array{GreensEltype, 3}
@@ -41,7 +44,7 @@ mutable struct DQMCStack{GreensEltype<:Number, HoppingEltype<:Number} <: Abstrac
 
     # preallocated, reused arrays
     curr_U::Matrix{GreensEltype}
-    eV::Matrix{GreensEltype}
+    eV::InteractionMatType
 
     # hopping matrices (mu included)
     hopping_matrix_exp::Matrix{HoppingEltype}
@@ -65,18 +68,21 @@ mutable struct DQMCStack{GreensEltype<:Number, HoppingEltype<:Number} <: Abstrac
     chkr_mu_inv::SparseMatrixCSC{HoppingEltype, Int64}
 
 
-    DQMCStack{GreensEltype, HoppingEltype}() where {GreensEltype<:Number, HoppingEltype<:Number} = begin
+    function DQMCStack{GreensEltype, HoppingEltype, IntMatType}() where {
+            GreensEltype<:Number, HoppingEltype<:Number, IntMatType <: AbstractArray
+        }
         # @assert isleaftype(GreensEltype);
         # @assert isleaftype(HoppingEltype);
         @assert isconcretetype(GreensEltype);
         @assert isconcretetype(HoppingEltype);
+        @assert isconcretetype(IntMatType);
         new()
     end
 end
 
 # type helpers
-geltype(::Type{DQMCStack{G,H}}) where {G,H} = G
-heltype(::Type{DQMCStack{G,H}}) where {G,H} = H
+geltype(::Type{<: DQMCStack{G,H}}) where {G,H} = G
+heltype(::Type{<: DQMCStack{G,H}}) where {G,H} = H
 geltype(mc::DQMC{M, CB, CT, CAT, S}) where {M, CB, CT, CAT, S} = geltype(S)
 heltype(mc::DQMC{M, CB, CT, CAT, S}) where {M, CB, CT, CAT, S} = heltype(S)
 
@@ -128,7 +134,7 @@ function initialize_stack(mc::DQMC)
     end
 
     mc.s.curr_U = zeros(GreensEltype, flv*N, flv*N)
-    mc.s.eV = zeros(GreensEltype, flv*N, flv*N)
+    mc.s.eV = init_interaction_matrix(mc.model)
 
     # mc.s.hopping_matrix_exp = zeros(HoppingEltype, flv*N, flv*N)
     # mc.s.hopping_matrix_exp_inv = zeros(HoppingEltype, flv*N, flv*N)

--- a/src/linalg/UDT.jl
+++ b/src/linalg/UDT.jl
@@ -3,8 +3,9 @@
 ################################################################################
 
 # fully in-place
-# larger error than pivoted
+# Probably don't use this as it has a larger error than the pivoted version
 
+# Taken from julia Base
 @inline function reflector!(x::AbstractVector)
     n = length(x)
     @inbounds begin
@@ -48,11 +49,13 @@ end
     return A
 end
 
+
 """
     udt_AVX!(U::Matrix, D::Vector, T::Matrix)
 
-In-place calculation of a UDT decomposition. The matrix `T` is simultaniously
-the input matrix that is decomposed and an output matrix.
+In-place calculation of a UDT (unitary - diagonal - (upper-)triangular) 
+decomposition. The matrix `T` is simultaniously the input matrix that is 
+decomposed and the triangular output matrix.
 
 This assumes correctly sized square matrices as inputs.
 """
@@ -145,16 +148,16 @@ end
 end
 
 
-function indmaxcolumn(A::Matrix{T}, j=1, n=size(A, 1)) where {T<:Real}
-    max = zero(T)
+function indmaxcolumn(A::Matrix, j=1, n=size(A, 1))
+    max = 0.0
     @avx for k in j:n
-        max += conj(A[k, j]) * A[k, j]
+        max += abs2(A[k, j])
     end
     ii = j
     @inbounds for i in j+1:n
-        mi = zero(T)
+        mi = 0.0
         @avx for k in j:n
-            mi += conj(A[k, i]) * A[k, i]
+            mi += abs2(A[k, i])
         end
         if abs(mi) > max
             max = mi
@@ -165,19 +168,20 @@ function indmaxcolumn(A::Matrix{T}, j=1, n=size(A, 1)) where {T<:Real}
 end
 
 
-# (Much?) higher accuracy, but a bit slower
+# Much higher accuracy, but a bit slower
 """
     udt_AVX_pivot!(
         U::Matrix, D::Vector, T::Matrix[, 
         pivot::Vector, temp::Vector, apply_pivoting = Val(true)
     ])
 
-In-place calculation of a UDT decomposition. The matrix `T` is simultaniously
-the input matrix that is decomposed and an output matrix.
+In-place calculation of a UDT (unitary - diagonal - (upper-)triangular) 
+decomposition. The matrix `T` is simultaniously the input matrix that is 
+decomposed and the triangular output matrix.
 
 If `apply_pivoting = Val(true)` the `T` matrix will be pivoted such that 
 `U * Diagonal(D) * T` matches the input. 
-If `apply_pivoting = Val(false)` `T` will be a dirty upper triangular matrix 
+If `apply_pivoting = Val(false)` `T` will be a "dirty" upper triangular matrix 
 (i.e. with random values elsewhere) which still requires pivoting. 
 `rdivp!(A, T, temp, pivot)` is built explicitly for this case - it applies the 
 pivoting while calculating `A T^-1`.
@@ -275,7 +279,7 @@ function udt_AVX_pivot!(
     nothing
 end
 
-function _apply_pivot!(input::Matrix{C}, D, temp, pivot, ::Val{true}) where {C<:Real}
+function _apply_pivot!(input::Matrix{C}, D, temp, pivot, ::Val{true}) where C
     n = size(input, 1)
     @inbounds for i in 1:n
         d = 1.0 / D[i]
@@ -290,7 +294,7 @@ function _apply_pivot!(input::Matrix{C}, D, temp, pivot, ::Val{true}) where {C<:
         end
     end
 end
-function _apply_pivot!(input::Matrix{C}, D, temp, pivot, ::Val{false}) where {C <: Real}
+function _apply_pivot!(input::Matrix, D, temp, pivot, ::Val{false})
     n = size(input, 1)
     @inbounds for i in 1:n
         d = 1.0 / D[i]
@@ -302,213 +306,12 @@ end
 
 
 
-"""
-    calculate_greens_AVX!(Ul, Dl, Tl, Ur, Dr, Tr, G[, pivot])
-
-Calculates the Greens function matrix `G` from two UDT decompositions
-`Ul, Dl, Tl` and `Ur, Dr, Tr`. Additionally a `pivot` vector can be given. Note
-that all inputs will be overwritten.
-
-The UDT should follow from a set of slice_matrix multiplications, such that
-Ur, Dr, Tr = B(slice)' ... B(M)'
-Ul, Dl, Tl = B(slice-1) ... B(1)
-"""
-@bm function calculate_greens_AVX!(
-        Ul, Dl, Tl, Ur, Dr, Tr, G,
-        pivot = Vector{Int64}(undef, length(Dl)),
-        temp = Vector{eltype(G)}(undef, length(Dl))
-    )
-    # @bm "B1" begin
-        # Used: Ul, Dl, Tl, Ur, Dr, Tr
-        # TODO: [I + Ul Dl Tl Tr^† Dr Ur^†]^-1
-        # Compute: Dl * ((Tl * Tr) * Dr) -> Tr * Dr * G   (UDT)
-        vmul!(G, Tl, adjoint(Tr))
-        rvmul!(G, Diagonal(Dr))
-        lvmul!(Diagonal(Dl), G)
-        udt_AVX_pivot!(Tr, Dr, G, pivot, temp, Val(false)) # Dl available
-    # end
-
-    # @bm "B2" begin
-        # Used: Ul, Ur, G, Tr, Dr  (Ul, Ur, Tr unitary (inv = adjoint))
-        # TODO: [I + Ul Tr Dr G Ur^†]^-1
-        #     = [(Ul Tr) ((Ul Tr)^-1 (G Ur^†) + Dr) (G Ur)]^-1
-        #     = Ur G^-1 [(Ul Tr)^† Ur G^-1 + Dr]^-1 (Ul Tr)^†
-        # Compute: Ul Tr -> Tl
-        #          (Ur G^-1) -> Ur
-        #          ((Ul Tr)^† Ur G^-1) -> Tr
-        vmul!(Tl, Ul, Tr)
-        rdivp!(Ur, G, Ul, pivot) # requires unpivoted udt decompostion (Val(false))
-        vmul!(Tr, adjoint(Tl), Ur)
-    # end
-
-    # @bm "B3" begin
-        # Used: Tl, Ur, Tr, Dr
-        # TODO: Ur [Tr + Dr]^-1 Tl^† -> Ur [Tr]^-1 Tl^†
-        @avx for i in 1:length(Dr)
-            # G[i, i] = G[i, i] + Dr[i]
-            Tr[i, i] = Tr[i, i] + Dr[i]
-        end
-    # end
-
-    # @bm "B4" begin
-        # Used: Ur, Tr, Tl
-        # TODO: Ur [Tr]^-1 Tl^† -> Ur [Ul Dr Tr]^-1 Tl^† 
-        #    -> Ur Tr^-1 Dr^-1 Ul^† Tl^† -> Ur Tr^-1 Dr^-1 (Tl Ul)^†
-        # Compute: Ur Tr^-1 -> Ur,  Tl Ul -> Tr
-        udt_AVX_pivot!(Ul, Dr, Tr, pivot, temp, Val(false)) # Dl available
-        rdivp!(Ur, Tr, G, pivot) # requires unpivoted udt decompostion (false)
-        vmul!(Tr, Tl, Ul)
-    # end
-
-    # @bm "B5" begin
-        @avx for i in eachindex(Dr)
-            Dl[i] = 1.0 / Dr[i]
-        end
-    # end
-
-    # @bm "B6" begin
-        # Used: Ur, Tr, Dl, Ul, Tl
-        # TODO: (Ur Dl) Tr^† -> G
-        rvmul!(Ur, Diagonal(Dl))
-        vmul!(G, Ur, adjoint(Tr))
-    # end
-end
-
-
-function vmul!(C::Matrix{T}, A::Matrix{T}, B::Matrix{T}) where {T <: Real}
-    @avx for m in 1:size(A, 1), n in 1:size(B, 2)
-        Cmn = zero(eltype(C))
-        for k in 1:size(A, 2)
-            Cmn += A[m,k] * B[k,n]
-        end
-        C[m,n] = Cmn
-    end
-end
-function vmul!(C::Matrix{T}, A::Matrix{T}, B::Diagonal{T}) where {T <: Real}
-    @avx for m in 1:size(A, 1), n in 1:size(A, 2)
-        C[m,n] = A[m,n] * B[n,n]
-    end
-end
-function vmul!(C::Matrix{T}, A::Matrix{T}, X::Adjoint{T}) where {T <: Real}
-    B = X.parent
-    @avx for m in 1:size(A, 1), n in 1:size(B, 2)
-        Cmn = zero(eltype(C))
-        for k in 1:size(A, 2)
-            Cmn += A[m,k] * conj(B[n, k])
-        end
-        C[m,n] = Cmn
-    end
-end
-function vmul!(C::Matrix{T}, X::Adjoint{T}, B::Matrix{T}) where {T <: Real}
-    A = X.parent
-    @avx for m in 1:size(A, 1), n in 1:size(B, 2)
-        Cmn = zero(eltype(C))
-        for k in 1:size(A, 2)
-            Cmn += conj(A[k,m]) * B[k,n]
-        end
-        C[m,n] = Cmn
-    end
-end
-function rvmul!(A::Matrix{T}, B::Diagonal{T}) where {T <: Real}
-    @avx for m in 1:size(A, 1), n in 1:size(A, 2)
-        A[m,n] = A[m,n] * B[n,n]
-    end
-end
-function lvmul!(A::Diagonal{T}, B::Matrix{T}) where {T <: Real}
-    @avx for m in 1:size(B, 1), n in 1:size(B, 2)
-        B[m,n] = A[m, m] * B[m, n]
-    end
-end
-
-"""
-    rdivp!(A, T, O, pivot)
-
-Computes `A * T^-1` where `T` is an upper triangular matrix which should be 
-pivoted according to a pivoting vector `pivot`. `A`, `T` and `O` should all be
-square matrices of the same size. The result will be written to `A` without 
-changing `T`.
-"""
-function rdivp!(A, T, O, pivot)
-    # assume Diagonal is ±1!
-    @inbounds begin
-        N = size(A, 1)
-
-        # Apply pivot
-        for (j, p) in enumerate(pivot)
-            @avx for i in 1:N
-                O[i, j] = A[i, p]
-            end
-        end
-
-        # do the rdiv
-        # @avx will segfault on `k in 1:0`, so pull out first loop 
-        @avx for i in 1:N
-            A[i, 1] = O[i, 1] / T[1, 1]
-        end
-        for j in 2:N
-            @avx for i in 1:N
-                x = O[i, j]
-                for k in 1:j-1
-                    x -= A[i, k] * T[k, j]
-                end
-                A[i, j] = x / T[j, j]
-            end
-        end
-    end
-    A
-end
-
-
-
 ################################################################################
-### Complex Fallbacks
+### Complex pivoted UDT
 ################################################################################
 
 
 
-function indmaxcolumn(A::Matrix{T}, j=1, n=size(A, 1)) where T
-    max = 0.0
-    for k in j:n
-        max += abs2(A[k, j])
-    end
-    ii = j
-    @inbounds for i in j+1:n
-        mi = 0.0
-        for k in j:n
-            mi += abs2(A[k, i])
-        end
-        if abs(mi) > max
-            max = mi
-            ii = i
-        end
-    end
-    return ii, max
-end
-
-function _apply_pivot!(input::Matrix{C}, D, temp, pivot, ::Val{true}) where C
-    n = size(input, 1)
-    @inbounds for i in 1:n
-        d = 1.0 / D[i]
-        @inbounds for j in 1:i-1
-            temp[pivot[j]] = zero(C)
-        end
-        for j in i:n
-            temp[pivot[j]] = d * input[i, j]
-        end
-        for j in 1:n
-            input[i, j] = temp[j]
-        end
-    end
-end
-function _apply_pivot!(input::Matrix{C}, D, temp, pivot, ::Val{false}) where C
-    n = size(input, 1)
-    @inbounds for i in 1:n
-        d = 1.0 / D[i]
-        for j in i:n
-            input[i, j] = d * input[i, j]
-        end
-    end
-end
 
 
 # avx-less method for compatability with ComplexF64
@@ -601,38 +404,4 @@ function udt_AVX_pivot!(
     # end
 
     nothing
-end
-
-
-# Fallbacks for Complex numbers
-vmul!(C, A, B) = mul!(C, A, B)
-rvmul!(A, B) = rmul!(A, B)
-lvmul!(A, B) = lmul!(A, B)
-
-
-function rdivp!(A::Matrix{<: Complex}, T::Matrix{<: Complex}, O::Matrix{<: Complex}, pivot)
-    # assume Diagonal is ±1!
-    @inbounds begin
-        N = size(A, 1)
-
-        # Apply pivot
-        for (j, p) in enumerate(pivot)
-            for i in 1:N
-                O[i, j] = A[i, p]
-            end
-        end
-
-        # do the rdiv
-        # @avx will segfault on `k in 1:0`, so pull out first loop 
-        for j in 1:N
-            for i in 1:N
-                x = O[i, j]
-                @simd for k in 1:j-1
-                    x -= A[i, k] * T[k, j]
-                end
-                A[i, j] = x / T[j, j]
-            end
-        end
-    end
-    A
 end

--- a/src/linalg/UDT.jl
+++ b/src/linalg/UDT.jl
@@ -184,7 +184,8 @@ If `apply_pivoting = Val(true)` the `T` matrix will be pivoted such that
 If `apply_pivoting = Val(false)` `T` will be a "dirty" upper triangular matrix 
 (i.e. with random values elsewhere) which still requires pivoting. 
 `rdivp!(A, T, temp, pivot)` is built explicitly for this case - it applies the 
-pivoting while calculating `A T^-1`.
+pivoting while calculating `A T^-1`. Warning: BlockDiagonal matrices use 
+per-block pivoting.
 
 This assumes correctly sized square matrices as inputs.
 """

--- a/src/linalg/UDT.jl
+++ b/src/linalg/UDT.jl
@@ -331,7 +331,7 @@ end
 end
 
 
-function indmaxcolumn(A::Matrix{C}, j=1, n=size(A, 1)) where {C <: ComplexF64}
+function indmaxcolumn(A::AbstractMatrix{C}, j=1, n=size(A, 1)) where {C <: ComplexF64}
     max = 0.0
     for k in j:n
         max += abs2(A[k, j])

--- a/src/linalg/blockdiagonal.jl
+++ b/src/linalg/blockdiagonal.jl
@@ -1,0 +1,346 @@
+# TODO
+# - find need allocations in attractive case
+# - decimate allocations here
+# - I guess maybe it's additional Diagonal's etc?
+
+
+
+################################################################################
+### Type and general utility
+################################################################################
+
+
+struct BlockDiagonal{T, N, AT <: AbstractMatrix{T}} <: AbstractMatrix{T}
+    blocks::NTuple{N, AT}
+
+    function BlockDiagonal(blocks::NTuple{N, AT}) where {T, N, AT <: AbstractMatrix{T}}
+        n, m = size(first(blocks))
+        n == m || throw(ErrorException("Each block must be square."))
+        all(b -> size(b) == (n, n), blocks) || throw(ErrorException(
+            "All Blocks must have the same size."
+        ))
+        # One matrix with zeros is faster than multiple 3x3 matrices on my
+        # machine (avx2). This will most likely depend on AVX version...
+        # if n < 4
+        #     full = zeros(T, n*N, n*N)
+        #     for i in 1:N
+        #         @views copyto!(full[(i-1)*n+1 : i*n, (i-1)*n+1 : i*n], blocks[i])
+        #     end
+        #     new{T, 1, AT}((full,))
+        # else
+            new{T, N, AT}(blocks)
+        # end
+    end
+end
+
+BlockDiagonal(blocks::AT...) where {T, AT <: AbstractMatrix{T}} = BlockDiagonal(blocks)
+function BlockDiagonal{T, N, AT}(::UndefInitializer, n, m) where {T, N, AT}
+    n == m || throw(ErrorException("Each block must be square."))
+    (n, m) = divrem(n, N)
+    m == 0 || throw(ErrorException(
+        "The size of the Matrix is incompatible with the blocking ($n % $N != 0)"
+    ))
+    BlockDiagonal([AT(undef, n, n) for _ in 1:N]...)
+end
+function BlockDiagonal{T, N, AT}(::UniformScaling, n, m) where {T, N, AT}
+    n == m || throw(ErrorException("Each block must be square."))
+    (n, m) = divrem(n, N)
+    m == 0 || throw(ErrorException(
+        "The size of the Matrix is incompatible with the blocking ($n % $N != 0)"
+    ))
+    BlockDiagonal([AT(I, n, n) for _ in 1:N]...)
+end
+
+function Base.Matrix(B::BlockDiagonal{T, N}) where {T, N}
+    n = size(B.blocks[1], 1)
+    M = N * n
+    output = zeros(T, M, M)
+    for i in 1:N
+        @views copyto!(output[(i-1)*n+1 : i*n, (i-1)*n+1 : i*n], B.blocks[i])
+    end
+    output
+end
+
+function Base.checkbounds(B::BlockDiagonal{T, N}, i, j) where {T, N}
+    @inbounds n = size(B.blocks[1], 1)
+    (1 ≤ i ≤ N*n) && (1 ≤ j ≤ N*n)
+end
+
+function Base.getindex(B::BlockDiagonal{T, N}, i, j) where {T, N}
+    @boundscheck checkbounds(B, i, j)
+    @inbounds n = size(B.blocks[1], 1)
+
+    b, k = divrem(i-1, n)
+    _b, l = divrem(j-1, n)
+    
+    if b != _b
+        return zero(T)
+    else
+        @inbounds return B.blocks[b+1][k+1, l+1]
+    end
+end
+
+function Base.copyto!(B1::BlockDiagonal{T, N}, B2::BlockDiagonal{T, N}) where {T, N}
+    for i in 1:N
+        copyto!(B1.blocks[i], B2.blocks[i])
+    end
+end
+function Base.copyto!(B::BlockDiagonal{T, N}, ::UniformScaling) where {T, N}
+    for i in 1:N
+        copyto!(B.blocks[i], I)
+    end
+end
+
+# for Base.show
+function Base.size(B::BlockDiagonal{T, N}) where {T, N}
+    @inbounds n = size(B.blocks[1], 1)
+    (n*N, n*N)
+end
+
+# Needed for tests
+Base.copy(B::BlockDiagonal) = deepcopy(B)
+
+# Needed for stack building (shouldn't be performance critical)
+function Base.:(*)(x::T, B::BlockDiagonal{T, N, AT}) where {T<:Number, N, AT<:AbstractMatrix{T}}
+    BlockDiagonal(map(block -> x * block, B.blocks)...)
+end
+Base.:(*)(B::BlockDiagonal{T, N, AT}, x::T) where {T<:Number, N, AT<:AbstractMatrix{T}} = x * B
+function Base.:(*)(B1::BlockDiagonal{T, N, AT}, B2::BlockDiagonal{T, N, AT}) where {
+        T<:Number, N, AT<:AbstractMatrix{T}
+    }
+    BlockDiagonal(map(*, B1.blocks, B2.blocks)...)
+end
+
+function Base.exp(B::BlockDiagonal{T, N, AT}) where {T<:Number, N, AT<:AbstractMatrix{T}}
+    BlockDiagonal(map(block ->exp(block), B.blocks)...)
+end
+
+
+
+################################################################################
+### AVX-powered matrix multiplications
+################################################################################
+
+
+
+function vmul!(C::BlockDiagonal{T, N}, A::BlockDiagonal{T, N}, B::BlockDiagonal{T, N}) where {T, N}
+    @inbounds for i in 1:N
+        vmul!(C.blocks[i], A.blocks[i], B.blocks[i])
+    end
+end
+function vmul!(C::BlockDiagonal{T, N}, A::BlockDiagonal{T, N}, B::Diagonal{T}) where {T<:Real, N}
+    # Assuming correct size
+    @inbounds n = size(A.blocks[1], 1)
+    @inbounds for i in 1:N
+        c = C.blocks[i]
+        a = A.blocks[i]
+        @avx for k in 1:n, l in 1:n
+            c[k,l] = a[k,l] * B.diag[(i-1)*n + l]
+        end
+    end
+end
+function vmul!(C::BlockDiagonal{T, N}, A::Diagonal{T}, B::BlockDiagonal{T, N}) where {T<:Real, N}
+    # Assuming correct size
+    @inbounds n = size(C.blocks[1], 1)
+    @inbounds for i in 1:N
+        c = C.blocks[i]
+        b = B.blocks[i]
+        @avx for k in 1:n, l in 1:n
+            c[k,l] = A.diag[(i-1)*n + k] * b[k,l]
+        end
+    end
+end
+function vmul!(C::BlockDiagonal{T, N}, A::BlockDiagonal{T, N}, X::Adjoint{T}) where {T<:Real, N}
+    B = X.parent
+    @inbounds n = size(C.blocks[1], 1)
+    @inbounds for i in 1:N
+        a = A.blocks[i]
+        b = B.blocks[i]
+        c = C.blocks[i]
+        @avx for k in 1:n, l in 1:n
+            Ckl = zero(eltype(c))
+            for m in 1:n
+                Ckl += a[k,m] * b[l, m]
+            end
+            c[k,l] = Ckl
+        end
+    end
+end
+function vmul!(C::BlockDiagonal{T, N}, X::Adjoint{T}, B::BlockDiagonal{T, N}) where {T<:Real, N}
+    A = X.parent
+    @inbounds n = size(C.blocks[1], 1)
+    @inbounds for i in 1:N
+        a = A.blocks[i]
+        b = B.blocks[i]
+        c = C.blocks[i]
+        @avx for k in 1:n, l in 1:n
+            Ckl = zero(eltype(c))
+            for m in 1:n
+                Ckl += a[m,k] * b[m,l]
+            end
+            c[k,l] = Ckl
+        end
+    end
+end
+function rvmul!(A::BlockDiagonal{T, N}, B::Diagonal) where {T, N}
+    # Assuming correct size
+    @inbounds n = size(A.blocks[1], 1)
+    @inbounds for i in 1:N
+        @views rvmul!(A.blocks[i], Diagonal(B.diag[(i-1)*n+1 : i*n]))
+    end
+end
+function lvmul!(A::Diagonal, B::BlockDiagonal{T, N}) where {T, N}
+    # Assuming correct size
+    @inbounds n = size(B.blocks[1], 1)
+    @inbounds for i in 1:N
+        @views lvmul!(Diagonal(A.diag[(i-1)*n+1 : i*n]), B.blocks[i])
+    end
+end
+
+function rvadd!(B::BlockDiagonal{T, N}, D::Diagonal{T}) where {T<:Real, N}
+    # Assuming correct size
+    @inbounds n = size(B.blocks[1], 1)
+    @inbounds for i in 1:N
+        a = B.blocks[i]
+        offset = (i-1) * n
+        @avx for j in 1:n
+            a[j, j] = a[j, j] + D.diag[j+offset]
+        end
+    end
+end
+
+
+function rdivp!(A::BD, T::BD, O::BD, pivot) where {ET<:Real, N, BD <: BlockDiagonal{ET, N}}
+    # assume Diagonal is ±1!
+    @inbounds begin
+        n = size(A.blocks[1], 1)
+
+        # Apply pivot
+        for b in 1:N
+            o = O.blocks[b]
+            a = A.blocks[b]
+            t = T.blocks[b]
+            offset = (b-1)*n
+
+            for j in 1:n
+                p = pivot[j + offset]
+                @avx for i in 1:n
+                    o[i, j] = a[i, p]
+                end
+            end
+
+            # do the rdiv
+            # @avx will segfault on `k in 1:0`, so pull out first loop 
+            invt11 = 1.0 / t[1, 1]
+            @avx for i in 1:n
+                a[i, 1] = o[i, 1] * invt11
+            end
+            for j in 2:n
+                invtjj = 1.0 / t[j, j]
+                @avx for i in 1:n
+                    x = o[i, j]
+                    for k in 1:j-1
+                        x -= a[i, k] * t[k, j]
+                    end
+                    a[i, j] = x * invtjj
+                end
+            end
+        end
+    end
+    A
+end
+
+
+
+################################################################################
+### Fallbacks
+################################################################################
+
+
+
+function vmul!(C::BlockDiagonal{T, N}, A::Diagonal{T}, B::BlockDiagonal{T, N}) where {T, N}
+    # Assuming correct size
+    @inbounds n = size(C.blocks[1], 1)
+    @inbounds for i in 1:N
+        @views vmul!(C.blocks[i], Diagonal(A.diag[(i-1)*n+1 : i*n]), B.blocks[i])
+    end
+end
+function vmul!(C::BlockDiagonal{T, N}, A::BlockDiagonal{T, N}, B::Diagonal) where {T, N}
+    # Assuming correct size
+    @inbounds n = size(C.blocks[1], 1)
+    @inbounds for i in 1:N
+        @views vmul!(C.blocks[i], A.blocks[i], Diagonal(B.diag[(i-1)*n+1 : i*n]))
+    end
+end
+function vmul!(C::BlockDiagonal{T, N}, A::BlockDiagonal{T, N}, X::Adjoint{T}) where {T, N}
+    B = X.parent
+    @inbounds for i in 1:N
+        vmul!(C.blocks[i], A.blocks[i], adjoint(B.blocks[i]))
+    end
+end
+function vmul!(C::BlockDiagonal{T, N}, X::Adjoint{T}, B::BlockDiagonal{T, N}) where {T, N}
+    A = X.parent
+    @inbounds for i in 1:N
+        vmul!(C.blocks[i], adjoint(A.blocks[i]), B.blocks[i])
+    end
+end
+function rvadd!(B::BlockDiagonal{T, N}, D::Diagonal{T}) where {T, N}
+    # Assuming correct size
+    @inbounds n = size(B.blocks[1], 1)
+    @inbounds for i in 1:N
+        @views rvadd!(B.blocks[i], Diagonal(D.diag[(i-1)*n+1 : i*n]))
+    end
+end
+function rdivp!(A::BD, T::BD, O::BD, pivot) where {ET, N, BD <: BlockDiagonal{ET, N}}
+    # Assuming correct size
+    @inbounds n = size(T.blocks[1], 1)
+    @inbounds for i in 1:N
+        @views rdivp!(A.blocks[i], T.blocks[i], O.blocks[i], pivot[(i-1)*n+1 : i*n])
+    end
+    A
+end
+
+
+
+################################################################################
+### UDT
+################################################################################
+
+
+
+function udt_AVX_pivot!(
+        U::BlockDiagonal{Float64, N, AT}, 
+        D::AbstractArray{Float64, 1}, 
+        input::BlockDiagonal{Float64, N, AT},
+        pivot::AbstractArray{Int64, 1} = Vector(UnitRange(1:size(input, 1))),
+        temp::AbstractArray{Float64, 1} = Vector{Float64}(undef, length(D)),
+        apply_pivot::Val = Val(true)
+    ) where {N, AT <: AbstractMatrix{Float64}}
+    # Assuming correct size
+    @inbounds n = size(input.blocks[1], 1)
+    @inbounds for i in 1:N
+        @views udt_AVX_pivot!(
+            U.blocks[i], D[(i-1)*n+1 : i*n], input.blocks[i],
+            pivot[(i-1)*n+1 : i*n], temp[(i-1)*n+1 : i*n], apply_pivot
+        )
+        # pivot[(i-1)*n+1 : i*n] .+= (i-1)*n
+    end
+end
+function udt_AVX_pivot!(
+        U::BlockDiagonal{ComplexF64, N, AT}, 
+        D::AbstractArray{Float64, 1}, 
+        input::BlockDiagonal{ComplexF64, N, AT},
+        pivot::AbstractArray{Int64, 1} = Vector(UnitRange(1:size(input, 1))),
+        temp::AbstractArray{ComplexF64, 1} = Vector{ComplexF64}(undef, length(D)),
+        apply_pivot::Val = Val(true)
+    ) where {N, AT <: AbstractMatrix{ComplexF64}}
+    # Assuming correct size
+    @inbounds n = size(input.blocks[1], 1)
+    @inbounds for i in 1:N
+        @views udt_AVX_pivot!(
+            U.blocks[i], D[(i-1)*n+1 : i*n], input.blocks[i],
+            pivot[(i-1)*n+1 : i*n], temp[(i-1)*n+1 : i*n], apply_pivot
+        )
+        # pivot[(i-1)*n+1 : i*n] .+= (i-1)*n
+    end
+end

--- a/src/linalg/complex.jl
+++ b/src/linalg/complex.jl
@@ -10,7 +10,7 @@ function vmuladd!(C::Matrix{T}, A::Matrix{T}, B::Matrix{T}, factor::T = T(1)) wh
         for k in 1:size(A, 2)
             Cmn += A[m,k] * B[k,n]
         end
-        C[m,n] += facotr * Cmn
+        C[m,n] += factor * Cmn
     end
 end
 function vmuladd!(C::Matrix{T}, A::Matrix{T}, B::Diagonal{T}, factor::T = T(1)) where {T <: Real}
@@ -23,7 +23,7 @@ function vmuladd!(C::Matrix{T}, A::Matrix{T}, X::Adjoint{T}, factor::T = T(1)) w
     @avx for m in 1:size(A, 1), n in 1:size(B, 2)
         Cmn = zero(eltype(C))
         for k in 1:size(A, 2)
-            Cmn += A[m,k] * conj(B[n, k])
+            Cmn += A[m,k] * B[n, k]
         end
         C[m,n] += factor * Cmn
     end
@@ -33,9 +33,29 @@ function vmuladd!(C::Matrix{T}, X::Adjoint{T}, B::Matrix{T}, factor::T = T(1)) w
     @avx for m in 1:size(A, 1), n in 1:size(B, 2)
         Cmn = zero(eltype(C))
         for k in 1:size(A, 2)
-            Cmn += conj(A[k,m]) * B[k,n]
+            Cmn += A[k,m] * B[k,n]
         end
         C[m,n] += factor * Cmn
+    end
+end
+function vmul!(C::Matrix{T}, A::Matrix{T}, X::Adjoint{T}, factor::T) where {T <: Real}
+    B = X.parent
+    @avx for m in 1:size(A, 1), n in 1:size(B, 2)
+        Cmn = zero(eltype(C))
+        for k in 1:size(A, 2)
+            Cmn += A[m,k] * B[n, k]
+        end
+        C[m,n] = factor * Cmn
+    end
+end
+function vmul!(C::Matrix{T}, X::Adjoint{T}, B::Matrix{T}, factor::T) where {T <: Real}
+    A = X.parent
+    @avx for m in 1:size(A, 1), n in 1:size(B, 2)
+        Cmn = zero(eltype(C))
+        for k in 1:size(A, 2)
+            Cmn += A[k,m] * B[k,n]
+        end
+        C[m,n] = factor * Cmn
     end
 end
 
@@ -47,13 +67,13 @@ end
 
 
 
-const CMat64 = StructArray{Complex{Float64},2,NamedTuple{(:re, :im),Tuple{Array{Float64,2},Array{Float64,2}}},Int64}
-const CVec64 = StructArray{Complex{Float64},1,NamedTuple{(:re, :im),Tuple{Array{Float64,1},Array{Float64,1}}},Int64}
+const CMat64 = StructArray{Complex{Float64},2,NamedTuple{(:re, :im), Tuple{AT, AT}}, I} where {AT <: AbstractArray{Float64, 2}, I}
+const CVec64 = StructArray{Complex{Float64},1,NamedTuple{(:re, :im), Tuple{AT, AT}}, I} where {AT <: AbstractArray{Float64, 1}, I}
 
 function vmul!(C::CMat64, A::CMat64, B::CMat64)
     @warn "Complex StructArrays are untested not really optimized." maxlog=10
     vmul!(   C.re, A.re, B.re)     # C.re = A.re * B.re
-    vmuladd!(C.re, A.im, B.im, -1) # C.re = C.re - A.im * B.im
+    vmuladd!(C.re, A.im, B.im, -1.0) # C.re = C.re - A.im * B.im
     vmul!(   C.im, A.re, B.im)     # C.im = A.re * B.im
     vmuladd!(C.im, A.im, B.re)     # C.im = C.im + A.im * B.re
 end
@@ -75,17 +95,17 @@ function vmul!(C::CMat64, A::CMat64, X::Adjoint{T, CMat64}) where {T <: ComplexF
     @warn "Complex StructArrays are untested not really optimized." maxlog=10
     B = X.parent
     vmul!(   C.re, A.re, adjoint(B.re))
-    vmuladd!(C.re, A.im, adjoint(B.im), -1.0)
-    vmul!(   C.im, A.re, adjoint(B.im))
+    vmuladd!(C.re, A.im, adjoint(B.im), 1.0)
+    vmul!(   C.im, A.re, adjoint(B.im), -1.0)
     vmuladd!(C.im, A.im, adjoint(B.re))
 end
 function vmul!(C::CMat64, X::Adjoint{T}, B::CMat64) where {T <: Real}
     @warn "Complex StructArrays are untested not really optimized." maxlog=10
     A = X.parent
     vmul!(   C.re, adjoint(A.re), B.re)
-    vmuladd!(C.re, adjoint(A.im), B.im, -1.0)
+    vmuladd!(C.re, adjoint(A.im), B.im, 1.0)
     vmul!(   C.im, adjoint(A.re), B.im)
-    vmuladd!(C.im, adjoint(A.im), B.re)
+    vmuladd!(C.im, adjoint(A.im), B.re, -1.0)
 end
 
 function rvmul!(A::CMat64, B::Diagonal{T}) where {T <: Real}
@@ -113,6 +133,14 @@ function lvmul!(A::Diagonal{ComplexF64}, B::CMat64)
 end
 
 rvadd!(A::CMat64, D::Diagonal{T}) where {T <: Real} = rvadd!(A.re, D)
+
+
+
+##################################################
+### TODO
+##################################################
+
+
 
 function rdivp!(A::CMat64, T::CMat64, O::CMat64, pivot)
     # assume Diagonal is ±1!
@@ -181,13 +209,82 @@ end
 
 
 
-
-
 ################################################################################
 ### UDT
 ################################################################################
 
 
+
+@inline function reflector!(x::CMat64, normu, j=1, n=size(x, 1))
+    @inbounds begin
+        ξ1 = x[j, j]
+        if iszero(normu)
+            return zero(ξ1) #zero(ξ1/normu)
+        end
+        normu = sqrt(normu)
+        ν = LinearAlgebra.copysign(normu, real(ξ1))
+        ξ1 += ν
+        invξ1 = 1.0 / ξ1
+        x.re[j, j] = -ν
+        @avx for i = j+1:n
+            x.re[i, j] = x.re[i, j] * real(invξ1)
+        end
+        @avx for i = j+1:n
+            x.re[i, j] = -x.im[i, j] * imag(invξ1)
+        end
+        @avx for i = j+1:n
+            x.im[i, j] = x.im[i, j] * real(invξ1)
+        end
+        @avx for i = j+1:n
+            x.im[i, j] = x.re[i, j] * imag(invξ1)
+        end
+    end
+    ξ1/ν
+end
+
+@inline function reflectorApply!(x::CVec64, τ::Number, A::CMat64)
+    m, n = size(A)
+    @inbounds for j = 1:n
+        # dot
+        vAj_re = A.re[1, j]
+        @avx for i = 2:m
+            vAj_re += x.re[i] * A.re[i, j]
+        end
+        @avx for i = 2:m
+            vAj_re += x.im[i] * A.im[i, j]
+        end
+
+        vAj_im = A.im[1, j]
+        @avx for i = 2:m
+            vAj_im -= x.im[i] * A.re[i, j]
+        end
+        @avx for i = 2:m
+            vAj_im += x.re[i] * A.im[i, j]
+        end
+
+        temp = real(τ) * vAj_re + imag(τ) * vAj_im
+        vAj_im = real(τ) * vAj_im - imag(τ) * vAj_re
+        vAj_re = temp
+
+        # ger
+        A.re[1, j] -= vAj_re
+        @avx for i = 2:m
+            A.re[i, j] -= x.re[i] * vAj_re
+        end
+        @avx for i = 2:m
+            A.re[i, j] += x.im[i] * vAj_im
+        end
+
+        A.im[1, j] -= vAj_im
+        @avx for i = 2:m
+            A.im[i, j] -= x.re[i] * vAj_im
+        end
+        @avx for i = 2:m
+            A.im[i, j] -= x.im[i] * vAj_re
+        end
+    end
+    return A
+end
 
 function udt_AVX_pivot!(
         U::CMat64, 
@@ -240,20 +337,47 @@ function udt_AVX_pivot!(
         MonteCarlo.reflectorApply!(x, τj, LinearAlgebra.view(input, j:n, j+1:n))
     end
 
-    copyto!(U, I)
+    copyto!(U.re, I)
+    copyto!(U.im, 0.0)
     @inbounds begin
-        U[n, n] -= temp[n]
+        U.re[n, n] -= temp.re[n]
+        U.im[n, n] -= temp.im[n]
         for k = n-1:-1:1
             for j = k:n
-                vBj = U[k,j]
-                for i = k+1:n
-                    vBj += conj(input[i,k]) * U[i,j]
+                vBj_re = U.re[k,j]
+                @avx for i = k+1:n
+                    vBj_re += input.re[i,k] * U.re[i,j]
                 end
-                vBj = temp[k]*vBj
-                U[k,j] -= vBj
-                for i = k+1:n
-                    U[i,j] -= input[i,k] * vBj
+                @avx for i = k+1:n
+                    vBj_re += input.im[i,k] * U.im[i,j]
                 end
+                vBj_im = U.im[k,j]
+                @avx for i = k+1:n
+                    vBj_im += input.re[i,k] * U.im[i,j]
+                end
+                @avx for i = k+1:n
+                    vBj_im -= input.im[i,k] * U.re[i,j]
+                end
+
+                re = temp.re[k] * vBj_re - temp.im[k] * vBj_im
+                vBj_im = temp.im[k] * vBj_re + temp.re[k] * vBj_im
+                vBj_re = re
+
+                U.re[k,j] -= vBj_re
+                U.im[k,j] -= vBj_im
+                @avx for i = k+1:n
+                    U.re[i,j] -= input.re[i,k] * vBj_re
+                end
+                @avx for i = k+1:n
+                    U.re[i,j] += input.im[i,k] * vBj_im
+                end
+                @avx for i = k+1:n
+                    U.im[i,j] -= input.im[i,k] * vBj_re
+                end
+                @avx for i = k+1:n
+                    U.im[i,j] -= input.re[i,k] * vBj_im
+                end
+                
             end
         end
     end

--- a/src/linalg/complex.jl
+++ b/src/linalg/complex.jl
@@ -1,0 +1,231 @@
+################################################################################
+### Helpers
+################################################################################
+
+
+
+function vmuladd!(C::Matrix{T}, A::Matrix{T}, B::Matrix{T}, factor::T = T(1)) where {T <: Real}
+    @avx for m in 1:size(A, 1), n in 1:size(B, 2)
+        Cmn = zero(eltype(C))
+        for k in 1:size(A, 2)
+            Cmn += A[m,k] * B[k,n]
+        end
+        C[m,n] += facotr * Cmn
+    end
+end
+function vmuladd!(C::Matrix{T}, A::Matrix{T}, B::Diagonal{T}, factor::T = T(1)) where {T <: Real}
+    @avx for m in 1:size(A, 1), n in 1:size(A, 2)
+        C[m,n] += factor * A[m,n] * B[n,n]
+    end
+end
+function vmuladd!(C::Matrix{T}, A::Matrix{T}, X::Adjoint{T}, factor::T = T(1)) where {T <: Real}
+    B = X.parent
+    @avx for m in 1:size(A, 1), n in 1:size(B, 2)
+        Cmn = zero(eltype(C))
+        for k in 1:size(A, 2)
+            Cmn += A[m,k] * conj(B[n, k])
+        end
+        C[m,n] += factor * Cmn
+    end
+end
+function vmuladd!(C::Matrix{T}, X::Adjoint{T}, B::Matrix{T}, factor::T = T(1)) where {T <: Real}
+    A = X.parent
+    @avx for m in 1:size(A, 1), n in 1:size(B, 2)
+        Cmn = zero(eltype(C))
+        for k in 1:size(A, 2)
+            Cmn += conj(A[k,m]) * B[k,n]
+        end
+        C[m,n] += factor * Cmn
+    end
+end
+
+
+
+################################################################################
+### Overloads for complex StructArrays
+################################################################################
+
+
+
+const CMat64 = StructArray{Complex{Float64},2,NamedTuple{(:re, :im),Tuple{Array{Float64,2},Array{Float64,2}}},Int64}
+const CVec64 = StructArray{Complex{Float64},1,NamedTuple{(:re, :im),Tuple{Array{Float64,1},Array{Float64,1}}},Int64}
+
+function vmul!(C::CMat64, A::CMat64, B::CMat64)
+    @warn "Complex StructArrays are untested not really optimized." maxlog=10
+    vmul!(   C.re, A.re, B.re)     # C.re = A.re * B.re
+    vmuladd!(C.re, A.im, B.im, -1) # C.re = C.re - A.im * B.im
+    vmul!(   C.im, A.re, B.im)     # C.im = A.re * B.im
+    vmuladd!(C.im, A.im, B.re)     # C.im = C.im + A.im * B.re
+end
+
+function vmul!(C::CMat64, A::CMat64, B::Diagonal{T}) where {T <: Real}
+    @warn "Complex StructArrays are untested not really optimized." maxlog=10
+    vmul!(C.re, A.re, B)
+    vmul!(C.im, A.im, B)
+end
+function vmul!(C::CMat64, A::CMat64, B::Diagonal{ComplexF64, CVecF64})
+    @warn "Complex StructArrays are untested not really optimized." maxlog=10
+    vmul!(   C.re, A.re, B.re)
+    vmuladd!(C.re, A.im, B.im, -1.0)
+    vmul!(   C.im, A.re, B.im)
+    vmuladd!(C.im, A.im, B.re)
+end
+
+function vmul!(C::CMat64, A::CMat64, X::Adjoint{T, CMat64}) where {T <: ComplexF64}
+    @warn "Complex StructArrays are untested not really optimized." maxlog=10
+    B = X.parent
+    vmul!(   C.re, A.re, adjoint(B.re))
+    vmuladd!(C.re, A.im, adjoint(B.im), -1.0)
+    vmul!(   C.im, A.re, adjoint(B.im))
+    vmuladd!(C.im, A.im, adjoint(B.re))
+end
+function vmul!(C::CMat64, X::Adjoint{T}, B::CMat64) where {T <: Real}
+    @warn "Complex StructArrays are untested not really optimized." maxlog=10
+    A = X.parent
+    vmul!(   C.re, adjoint(A.re), B.re)
+    vmuladd!(C.re, adjoint(A.im), B.im, -1.0)
+    vmul!(   C.im, adjoint(A.re), B.im)
+    vmuladd!(C.im, adjoint(A.im), B.re)
+end
+
+function rvmul!(A::CMat64, B::Diagonal{T}) where {T <: Real}
+    @warn "Complex StructArrays are untested not really optimized." maxlog=10
+    rvmul!(A.re, B)
+    rvmul!(A.im, B)
+end
+function rvmul!(A::CMat64, B::Diagonal{ComplexF64})
+    @warn "Complex StructArrays are untested not really optimized." maxlog=10
+    @inbounds for m in 1:size(A, 1), n in 1:size(A, 2)
+        A[m,n] = A[m, n] * B[n,n]
+    end
+end
+
+function lvmul!(A::Diagonal{T}, B::CMat64) where {T <: Real}
+    @warn "Complex StructArrays are untested not really optimized." maxlog=10
+    lvmul!(A, B.re)
+    lvmul!(A, B.im)
+end
+function lvmul!(A::Diagonal{ComplexF64}, B::CMat64)
+    @warn "Complex StructArrays are untested not really optimized." maxlog=10
+    @inbounds for m in 1:size(B, 1), n in 1:size(B, 2)
+        B[m,n] = A[m, m] * B[m, n]
+    end
+end
+
+
+
+################################################################################
+### UDT
+################################################################################
+
+
+
+function udt_AVX_pivot!(
+        U::CMat64, 
+        D::AbstractArray{Float64, 1}, 
+        input::CMat64,
+        pivot::AbstractArray{Int64, 1} = Vector(UnitRange(1:size(input, 1))),
+        temp::AbstractArray{C, 1} = Vector{C}(undef, length(D)),
+        apply_pivot::Val = Val(true)
+    ) where {C <: Complex}
+    # Assumptions:
+    # - all matrices same size
+    # - input can be changed (input becomes T)
+    @warn "Complex StructArrays are untested not really optimized." maxlog=10
+
+    n = size(input, 1)
+    @inbounds for i in 1:n
+        pivot[i] = i
+    end
+
+    # TODO optimize
+    @inbounds for j = 1:n
+        # Find column with maximum norm in trailing submatrix
+        jm, maxval = indmaxcolumn(input, j, n)
+
+        if jm != j
+            # Flip elements in pivoting vector
+            tmpp = pivot[jm]
+            pivot[jm] = pivot[j]
+            pivot[j] = tmpp
+
+            # Update matrix with
+            @avx for i = 1:n
+                tmp = input.re[i,jm]
+                input.re[i,jm] = input.re[i,j]
+                input.re[i,j] = tmp
+            end
+            @avx for i = 1:n
+                tmp = input.im[i,jm]
+                input.im[i,jm] = input.im[i,j]
+                input.im[i,j] = tmp
+            end
+        end
+        
+        # Compute reflector of columns j
+        τj = reflector!(input, maxval, j, n)
+        temp[j] = τj
+
+        # Update trailing submatrix with reflector
+        x = LinearAlgebra.view(input, j:n, j)
+        MonteCarlo.reflectorApply!(x, τj, LinearAlgebra.view(input, j:n, j+1:n))
+    end
+
+    copyto!(U, I)
+    @inbounds begin
+        U[n, n] -= temp[n]
+        for k = n-1:-1:1
+            for j = k:n
+                vBj = U[k,j]
+                for i = k+1:n
+                    vBj += conj(input[i,k]) * U[i,j]
+                end
+                vBj = temp[k]*vBj
+                U[k,j] -= vBj
+                for i = k+1:n
+                    U[i,j] -= input[i,k] * vBj
+                end
+            end
+        end
+    end
+
+    @avx for i in 1:n
+        D[i] = abs(input.re[i, i])
+    end
+
+    _apply_pivot!(input, D, temp, pivot, apply_pivot)
+
+    nothing
+end
+
+function _apply_pivot!(input::CMatF64, D, temp, pivot, ::Val{true})
+    # TODO: optimize
+    n = size(input, 1)
+    @inbounds for i in 1:n
+        d = 1.0 / D[i]
+        for j in 1:i-1
+            temp[pivot[j]] = zero(C)
+        end
+        for j in i:n
+            temp[pivot[j]] = d * input[i, j]
+        end
+        for j in 1:n
+            input[i, j] = temp[j]
+        end
+    end
+end
+function _apply_pivot!(input::CMat64, D, temp, pivot, ::Val{false})
+    n = size(input, 1)
+    @inbounds for i in 1:n
+        d = 1.0 / D[i]
+        @avx for j in i:n
+            input.re[i, j] = d * input.re[i, j]
+        end
+    end
+    @inbounds for i in 1:n
+        d = 1.0 / D[i]
+        @avx for j in i:n
+            input.im[i, j] = d * input.im[i, j]
+        end
+    end
+end

--- a/src/linalg/general.jl
+++ b/src/linalg/general.jl
@@ -1,0 +1,132 @@
+################################################################################
+### AVX-powered matrix multiplications for real matrices
+################################################################################
+
+
+
+function vmul!(C::Matrix{T}, A::Matrix{T}, B::Matrix{T}) where {T <: Real}
+    @avx for m in 1:size(A, 1), n in 1:size(B, 2)
+        Cmn = zero(eltype(C))
+        for k in 1:size(A, 2)
+            Cmn += A[m,k] * B[k,n]
+        end
+        C[m,n] = Cmn
+    end
+end
+function vmul!(C::Matrix{T}, A::Matrix{T}, B::Diagonal{T}) where {T <: Real}
+    @avx for m in 1:size(A, 1), n in 1:size(A, 2)
+        C[m,n] = A[m,n] * B[n,n]
+    end
+end
+function vmul!(C::Matrix{T}, A::Matrix{T}, X::Adjoint{T}) where {T <: Real}
+    B = X.parent
+    @avx for m in 1:size(A, 1), n in 1:size(B, 2)
+        Cmn = zero(eltype(C))
+        for k in 1:size(A, 2)
+            Cmn += A[m,k] * conj(B[n, k])
+        end
+        C[m,n] = Cmn
+    end
+end
+function vmul!(C::Matrix{T}, X::Adjoint{T}, B::Matrix{T}) where {T <: Real}
+    A = X.parent
+    @avx for m in 1:size(A, 1), n in 1:size(B, 2)
+        Cmn = zero(eltype(C))
+        for k in 1:size(A, 2)
+            Cmn += conj(A[k,m]) * B[k,n]
+        end
+        C[m,n] = Cmn
+    end
+end
+function rvmul!(A::Matrix{T}, B::Diagonal{T}) where {T <: Real}
+    @avx for m in 1:size(A, 1), n in 1:size(A, 2)
+        A[m,n] = A[m,n] * B[n,n]
+    end
+end
+function lvmul!(A::Diagonal{T}, B::Matrix{T}) where {T <: Real}
+    @avx for m in 1:size(B, 1), n in 1:size(B, 2)
+        B[m,n] = A[m, m] * B[m, n]
+    end
+end
+
+
+
+"""
+    rdivp!(A, T, O, pivot)
+
+Computes `A * T^-1` where `T` is an upper triangular matrix which should be 
+pivoted according to a pivoting vector `pivot`. `A`, `T` and `O` should all be
+square matrices of the same size. The result will be written to `A` without 
+changing `T`.
+
+This function is written to work with (@ref)[`udt_AVX_pivot!`].
+"""
+function rdivp!(A, T, O, pivot)
+    # assume Diagonal is ±1!
+    @inbounds begin
+        N = size(A, 1)
+
+        # Apply pivot
+        for (j, p) in enumerate(pivot)
+            @avx for i in 1:N
+                O[i, j] = A[i, p]
+            end
+        end
+
+        # do the rdiv
+        # @avx will segfault on `k in 1:0`, so pull out first loop 
+        @avx for i in 1:N
+            A[i, 1] = O[i, 1] / T[1, 1]
+        end
+        for j in 2:N
+            @avx for i in 1:N
+                x = O[i, j]
+                for k in 1:j-1
+                    x -= A[i, k] * T[k, j]
+                end
+                A[i, j] = x / T[j, j]
+            end
+        end
+    end
+    A
+end
+
+
+
+################################################################################
+### Fallbacks for complex matrices
+################################################################################
+
+
+
+vmul!(C, A, B) = mul!(C, A, B)
+rvmul!(A, B) = rmul!(A, B)
+lvmul!(A, B) = lmul!(A, B)
+
+
+function rdivp!(A::Matrix{<: Complex}, T::Matrix{<: Complex}, O::Matrix{<: Complex}, pivot)
+    # assume Diagonal is ±1!
+    @inbounds begin
+        N = size(A, 1)
+
+        # Apply pivot
+        for (j, p) in enumerate(pivot)
+            for i in 1:N
+                O[i, j] = A[i, p]
+            end
+        end
+
+        # do the rdiv
+        # @avx will segfault on `k in 1:0`, so pull out first loop 
+        for j in 1:N
+            for i in 1:N
+                x = O[i, j]
+                @simd for k in 1:j-1
+                    x -= A[i, k] * T[k, j]
+                end
+                A[i, j] = x / T[j, j]
+            end
+        end
+    end
+    A
+end

--- a/src/linalg/general.jl
+++ b/src/linalg/general.jl
@@ -18,6 +18,11 @@ function vmul!(C::Matrix{T}, A::Matrix{T}, B::Diagonal{T}) where {T <: Real}
         C[m,n] = A[m,n] * B[n,n]
     end
 end
+function vmul!(C::Matrix{T}, A::Diagonal{T}, B::Matrix{T}) where {T <: Real}
+    @avx for m in 1:size(C, 1), n in 1:size(C, 2)
+        C[m,n] = A[m,m] * B[m,n]
+    end
+end
 function vmul!(C::Matrix{T}, A::Matrix{T}, X::Adjoint{T}) where {T <: Real}
     B = X.parent
     @avx for m in 1:size(A, 1), n in 1:size(B, 2)
@@ -45,7 +50,12 @@ function rvmul!(A::Matrix{T}, B::Diagonal{T}) where {T <: Real}
 end
 function lvmul!(A::Diagonal{T}, B::Matrix{T}) where {T <: Real}
     @avx for m in 1:size(B, 1), n in 1:size(B, 2)
-        B[m,n] = A[m, m] * B[m, n]
+        B[m,n] = A.diag[m] * B[m, n]
+    end
+end
+function rvadd!(A::Matrix{T}, D::Diagonal{T}) where {T <: Real}
+    @avx for i in axes(A, 1)
+        A[i, i] = A[i, i] + D.diag[i]
     end
 end
 
@@ -102,6 +112,7 @@ end
 vmul!(C, A, B) = mul!(C, A, B)
 rvmul!(A, B) = rmul!(A, B)
 lvmul!(A, B) = lmul!(A, B)
+rvadd!(A, B) = A .= A .+ B
 
 
 function rdivp!(A::Matrix{<: Complex}, T::Matrix{<: Complex}, O::Matrix{<: Complex}, pivot)

--- a/src/models/HubbardAttractive/HubbardModel.jl
+++ b/src/models/HubbardAttractive/HubbardModel.jl
@@ -30,6 +30,13 @@ function choose_lattice(::Type{<: HubbardModel}, dims, L)
     end
 end
 
+interaction_matrix_type(::Type{DQMC}, ::HubbardModel) = Diagonal{Float64, Vector{Float64}}
+
+function init_interaction_matrix(m::HubbardModel)
+    N = length(lattice(m))
+    flv = nflavors(m)
+    Diagonal(zeros(Float64, N*flv))
+end
 
 # deprecate this? maybe add nstates instead to avoid accessing model.flv?
 @inline nflavors(m::HubbardModel) = m.flv

--- a/src/models/HubbardAttractive/HubbardModelAttractive.jl
+++ b/src/models/HubbardAttractive/HubbardModelAttractive.jl
@@ -89,17 +89,21 @@ and store it in `result::Matrix`.
 This is a performance critical method.
 """
 @inline @bm function interaction_matrix_exp!(mc::DQMC, m::HubbardModelAttractive,
-            result::Matrix, conf::HubbardConf, slice::Int, power::Float64=1.)
+            result, conf::HubbardConf, slice::Int, power::Float64=1.)
     dtau = mc.p.delta_tau
     lambda = acosh(exp(0.5 * m.U * dtau))
 
-    z = zero(eltype(result))
-    @inbounds for j in eachindex(result)
-        result[j] = z
-    end
+    # z = zero(eltype(result))
+    # @inbounds for j in eachindex(result)
+    #     result[j] = z
+    # end
+    # N = size(result, 1)
+    # @inbounds for i in 1:N
+    #     result[i, i] = exp(sign(power) * lambda * conf[i, slice])
+    # end
     N = size(result, 1)
     @inbounds for i in 1:N
-        result[i, i] = exp(sign(power) * lambda * conf[i, slice])
+        result.diag[i] = exp(sign(power) * lambda * conf[i, slice])
     end
     nothing
 end

--- a/src/models/HubbardAttractive/HubbardModelRepulsive.jl
+++ b/src/models/HubbardAttractive/HubbardModelRepulsive.jl
@@ -55,6 +55,11 @@ Base.show(io::IO, m::MIME"text/plain", model::HubbardModelRepulsive) = print(io,
 # Convenience
 @inline parameters(m::HubbardModelRepulsive) = (L = m.L, t = m.t, U = m.U)
 
+# optional optimization
+hopping_matrix_type(::Type{DQMC}, ::HubbardModelRepulsive) = BlockDiagonal{Float64, 2, Matrix{Float64}}
+greens_matrix_type( ::Type{DQMC}, ::HubbardModelRepulsive) = BlockDiagonal{Float64, 2, Matrix{Float64}}
+
+
 
 """
     hopping_matrix(mc::DQMC, m::HubbardModelRepulsive)
@@ -72,18 +77,17 @@ actual simulation.
 """
 function hopping_matrix(mc::DQMC, model::HubbardModelRepulsive)
     N = length(model.l)
-    T = zeros(2N, 2N)
+    T = zeros(N, N)
 
     # Nearest neighbor hoppings
     @inbounds @views begin
         for (src, trg) in neighbors(model.l, Val(true))
             trg == -1 && continue
             T[trg, src] += -model.t
-            T[trg+N, src+N] += -model.t
         end
     end
 
-    return T
+    return BlockDiagonal(T, copy(T))
 end
 
 
@@ -195,14 +199,35 @@ end
     @bm "accept_local (finalize computation)" begin
         # G = G - IG * (R * Δ) * G[i:N:end, :]
 
-        @avx for m in axes(G, 1), n in axes(G, 2)
-            mc.s.greens_temp[m, n] = IGR[m, 1] * G[i, n] + IGR[m, 2] * G[i+N, n]
+        # @avx for m in axes(G, 1), n in axes(G, 2)
+        #     mc.s.greens_temp[m, n] = IGR[m, 1] * G[i, n] + IGR[m, 2] * G[i+N, n]
+        # end
+
+        # @avx for m in axes(G, 1), n in axes(G, 2)
+        #     G[m, n] = G[m, n] - mc.s.greens_temp[m, n]
+        # end
+
+        # BlockDiagonal version
+        G1 = G.blocks[1]
+        G2 = G.blocks[2]
+        temp1 = mc.s.greens_temp.blocks[1]
+        temp2 = mc.s.greens_temp.blocks[2]
+
+        @avx for m in axes(G1, 1), n in axes(G1, 2)
+            temp1[m, n] = IGR[m, 1] * G1[i, n]
+        end
+        @avx for m in axes(G2, 1), n in axes(G2, 2)
+            temp2[m, n] = IGR[m+N, 2] * G2[i, n]
         end
 
-        @avx for m in axes(G, 1), n in axes(G, 2)
-            G[m, n] = G[m, n] - mc.s.greens_temp[m, n]
+        @avx for m in axes(G1, 1), n in axes(G1, 2)
+            G1[m, n] = G1[m, n] - temp1[m, n]
+        end
+        @avx for m in axes(G2, 1), n in axes(G2, 2)
+            G2[m, n] = G2[m, n] - temp2[m, n]
         end
 
+        # Always
         conf[i, slice] *= -1
     end
 

--- a/src/models/HubbardAttractive/HubbardModelRepulsive.jl
+++ b/src/models/HubbardAttractive/HubbardModelRepulsive.jl
@@ -98,20 +98,27 @@ and store it in `result::Matrix`.
 This is a performance critical method.
 """
 @inline @bm function interaction_matrix_exp!(mc::DQMC, model::HubbardModelRepulsive,
-            result::Matrix, conf::HubbardConf, slice::Int, power::Float64=1.)
+            result, conf::HubbardConf, slice::Int, power::Float64=1.)
     dtau = mc.p.delta_tau
     lambda = acosh(exp(0.5 * model.U * dtau))
 
-    z = zero(eltype(result))
-    @inbounds for j in eachindex(result)
-        result[j] = z
-    end
+    # z = zero(eltype(result))
+    # @inbounds for j in eachindex(result)
+    #     result[j] = z
+    # end
+    # N = length(lattice(model))
+    # @inbounds for i in 1:N
+    #     result[i, i] = exp(sign(power) * lambda * conf[i, slice])
+    # end
+    # @inbounds for i in 1:N
+    #     result[i+N, i+N] = exp(-sign(power) * lambda * conf[i, slice])
+    # end
     N = length(lattice(model))
     @inbounds for i in 1:N
-        result[i, i] = exp(sign(power) * lambda * conf[i, slice])
+        result.diag[i] = exp(sign(power) * lambda * conf[i, slice])
     end
     @inbounds for i in 1:N
-        result[i+N, i+N] = exp(-sign(power) * lambda * conf[i, slice])
+        result.diag[i+N] = exp(-sign(power) * lambda * conf[i, slice])
     end
     nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,7 +69,7 @@ end
         include("ED/ED_tests.jl")
     end
 
-    @testset "File IO" begin
-        include("FileIO.jl")
-    end
+    # @testset "File IO" begin
+    #     include("FileIO.jl")
+    # end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,7 +69,7 @@ end
         include("ED/ED_tests.jl")
     end
 
-    # @testset "File IO" begin
-    #     include("FileIO.jl")
-    # end
+    @testset "File IO" begin
+        include("FileIO.jl")
+    end
 end

--- a/test/slice_matrices.jl
+++ b/test/slice_matrices.jl
@@ -129,3 +129,144 @@ end
         @test maximum(abs, input .- result) < 2dqmc.p.delta_tau
     end
 end
+
+using MonteCarlo: vmul!, lvmul!, rvmul!, rdivp!, udt_AVX_pivot!, BlockDiagonal
+
+@testset "Custom Linear Algebra " begin
+    for type in (Float64, ComplexF64)
+        @testset "avx multiplications ($type)" begin
+            A = rand(type, 16, 16)
+            B = rand(type, 16, 16)
+            C = rand(type, 16, 16)
+
+            vmul!(C, A, B)
+            @test A * B ≈ C
+
+            vmul!(C, A, B')
+            @test A * B' ≈ C
+
+            vmul!(C, A', B)
+            @test A' * B ≈ C
+
+            D = Diagonal(rand(16))
+            vmul!(C, A, D)
+            @test A * D ≈ C
+
+            copyto!(C, A)
+            rvmul!(C, D)
+            @test A * D ≈ C
+
+            copyto!(C, A)
+            lvmul!(D, C)
+            @test D * A ≈ C
+        end
+
+        @testset "UDT transformations + rdivp! ($type)" begin
+            U = Matrix{Float64}(undef, 16, 16)
+            D = Vector{Float64}(undef, 16)
+            T = rand(16, 16)
+            X = copy(T)
+            MonteCarlo.udt_AVX!(U, D, T)
+            @test U * Diagonal(D) * T ≈ X
+
+            U = Matrix{type}(undef, 16, 16)
+            T = rand(type, 16, 16)
+            X = copy(T)
+            pivot = Vector{Int64}(undef, 16)
+            tempv = Vector{type}(undef, 16)
+            udt_AVX_pivot!(U, D, T)
+            @test U * Diagonal(D) * T ≈ X
+
+            copyto!(T, X)
+            pivot = Vector{Int64}(undef, 16)
+            tempv = Vector{type}(undef, 16)
+            udt_AVX_pivot!(U, D, T, pivot, tempv, Val(false))
+            # pivoting matrix
+            P = zeros(length(pivot), length(pivot))
+            for (i, j) in enumerate(pivot)
+                P[i, j] = 1.0
+            end
+            @test U * Diagonal(D) * UpperTriangular(T) * P ≈ X
+
+            u = copy(U)
+            t = copy(T)
+            tmp = similar(T)
+            rdivp!(u, t, tmp, pivot)
+            @test u ≈ U * P' / UpperTriangular(T)
+        end
+    end
+
+    @testset "BlockDiagonal" begin
+        b1 = rand(4, 4)
+        b2 = rand(4, 4)
+
+        B = BlockDiagonal(b1, b2)
+        @test B isa BlockDiagonal{Float64, 2, Matrix{Float64}}
+        
+        # Check values/indexing
+        for i in 1:4, j in 1:4
+            @test B[i, j] == b1[i, j]
+            @test B[4+i, 4+j] == b2[i, j]
+            @test B[4+i, j] == 0.0
+            @test B[i, 4+j] == 0.0
+        end
+
+        B1 = copy(B)
+        M1 = Matrix(B1)
+        @test M1 == B1
+
+        B2 = BlockDiagonal(rand(4, 4), rand(4, 4))
+        M2 = Matrix(B2)
+        B3 = BlockDiagonal(rand(4, 4), rand(4, 4))
+        M3 = Matrix(B3)
+
+        # Test avx multiplications
+        vmul!(B1, B2, B3)
+        vmul!(M1, M2, M3)
+        @test M1 == B1
+
+        vmul!(B1, B2, adjoint(B3))
+        vmul!(M1, M2, adjoint(M3))
+        @test M1 == B1
+
+        vmul!(B1, adjoint(B2), B3)
+        vmul!(M1, adjoint(M2), M3)
+        @test M1 == B1
+
+        D = Diagonal(rand(8))
+        vmul!(B1, B2, D)
+        vmul!(M1, M2, D)
+        @test M1 == B1
+
+        rvmul!(B1, D)
+        rvmul!(M1, D)
+        @test M1 == B1
+
+        lvmul!(D, B1)
+        lvmul!(D, M1)
+        @test M1 == B1
+
+        # Test UDT and rdivp!
+        M2 = Matrix(B2)
+        D = rand(8)
+        pivot = Vector{Int64}(undef, 8)
+        tempv = Vector{Float64}(undef, 8)
+        udt_AVX_pivot!(B1, D, B2, pivot, tempv, Val(false))
+        
+        P = zeros(length(pivot), length(pivot))
+        # pivot is per block, temporary make it global (in the sense of matrix indices)
+        n = size(B1.blocks[1], 1); N = length(B.blocks)
+        for i in 1:N; pivot[(i-1)*n+1 : i*n] .+= (i-1)*n; end
+        for (i, j) in enumerate(pivot)
+            P[i, j] = 1.0
+        end
+        for i in 1:N; pivot[(i-1)*n+1 : i*n] .-= (i-1)*n; end
+        
+        @test Matrix(B1) * Diagonal(D) * UpperTriangular(Matrix(B2)) * P ≈ M2
+
+        M1 = Matrix(B1)
+        M2 = Matrix(B2)
+        rdivp!(B1, B2, B3, pivot)
+        @test B1 ≈ M1 * P' / UpperTriangular(M2)
+    end
+end 

--- a/test/slice_matrices.jl
+++ b/test/slice_matrices.jl
@@ -37,7 +37,7 @@ end
     m = HubbardModelAttractive(dims=1, L=8)
     dqmc = DQMC(m, beta=5.0)
     eT = dqmc.s.hopping_matrix_exp
-    eV = similar(eT)
+    eV = similar(dqmc.s.eV)
     A = similar(eT)
 
 


### PR DESCRIPTION
Implements optimizations for #78 and opens up more optimizations such as using `Diagonal` matrices as the interaction matrix or introducing specialized matrix types such as `BlockDiagonal` matrices for greens function etc.