### PR TITLE
remove full types from file loading

### DIFF
--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -91,7 +91,7 @@ function _generate_unique_filename(filename)
     filename * '.' * parts[end]
 end
 
-function to_tag(data::Union{JLDFile, JLD2.Group})
+function to_tag(data::Union{JLDFile, JLD2.Group, Dict{String, Any}})
     haskey(data, "tag") && return Val(Symbol(data["tag"]))
     haskey(data, "type") && return to_tag(data["type"])
     error("Failed to get tag from $data")

--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -91,6 +91,14 @@ function _generate_unique_filename(filename)
     filename * '.' * parts[end]
 end
 
+function to_tag(data::Union{JLDFile, JLD2.Group})
+    haskey(data, "tag") && return Val(Symbol(data["tag"]))
+    haskey(data, "type") && return to_tag(data["type"])
+    error("Failed to get tag from $data")
+end
+to_tag(::Type{<: AbstractLattice}) = Val(:Generic)
+to_tag(::Type{<: Model}) = Val(:Generic)
+
 """
     load(filename[, groups...])
 
@@ -120,18 +128,9 @@ function _load(data, g::String)
 
     haskey(data[g], "RNG") && load_rng!(data)
 
-    # type nonsense for dispatch
-    T = if haskey(data[g], "type"); data[g]["type"] 
-    elseif g == "Measurements"; Measurements
-    else throw(ErrorException(
-        "Failed to defer type for group \"$g\". To fix this, add a group " *
-        "\"type\" under \"$g\" with the relevant type. To manually load this " *
-        "group, call `MonteCarlo._load(::JLD2.Group, type)`."
-    ))
-    end
-    _load(data[g], T)
+    _load(data[g], to_tag(data[g]))
 end
-_load(data) = _load(data, data["type"])
+_load(data) = _load(data, to_tag(data))
 
 
 """
@@ -152,7 +151,7 @@ function resume!(filename; kwargs...)
         throw(ErrorException("Failed to load $filename version $(data["VERSION"])"))
     end
 
-    mc = _load(data["MC"], data["MC"]["type"])
+    mc = _load(data["MC"], to_tag(data["MC"]))
     resume_init!(mc)
     load_rng!(data)
     endswith(filename, "jld2") && close(data)
@@ -173,11 +172,8 @@ function save_mc(
     close(file)
     nothing
 end
-_load(_, ::Type{UnknownType}) = throw(ErrorException(
-    "Got UnknownType instead of a MonteCarloFlavor. This may be " * 
-    "caused by missing imports."
-))
-function _load(data, ::JLD2.UnknownType)
+to_tag(::Type{<: Union{UnknownType, JLD2.UnknownType}}) = Val{:UNKNOWN}
+function _load(data, ::Val{:UNKNOWN})
     @info "Failed to load (Unknowntype)"
     @info "Available fields: $(keys(data))"
     @info "You may be missing external packages."
@@ -206,7 +202,7 @@ function save_model(
 end
 function save_model(file::JLDFile, model, entryname::String)
     write(file, entryname * "/VERSION", 0)
-    write(file, entryname * "/type", typeof(model))
+    write(file, entryname * "/tag", "Generic")
     write(file, entryname * "/data", model)
     nothing
 end
@@ -220,7 +216,7 @@ The default `_load` will check that `data["VERSION"] == 0` and simply return
 `data["data"]`. You may implement `_load(data, ::Type{<: MyType})` to add
 specialized loading behavior.
 """
-function _load(data, ::Type{T}) where T
+function _load(data, ::Val{:Generic}) where T
     data["VERSION"] == 0 || throw(ErrorException(
         "Version $(data["VERSION"]) incompatabile with default _load for $T."
     ))
@@ -247,7 +243,7 @@ function save_lattice(
 end
 function save_lattice(file::JLDFile, lattice::AbstractLattice, entryname::String)
     write(file, entryname * "/VERSION", 0)
-    write(file, entryname * "/type", typeof(lattice))
+    write(file, entryname * "/tag", "Generic")
     write(file, entryname * "/data", lattice)
     nothing
 end

--- a/src/configurations.jl
+++ b/src/configurations.jl
@@ -229,3 +229,19 @@ function _save(file::JLDFile, ::Discarder, entryname::String="configs")
 end
 _load(data, ::Val{:Discarder}) = Discarder()
 to_tag(::Type{<: Discarder}) = Val(:Discarder)
+
+
+
+################################################################################
+### Utility
+################################################################################
+
+
+
+function Base.merge!(target::BufferedConfigRecorder, source::ConfigRecorder; rate = 1)
+    for i in eachindex(source.configs)
+        if i % rate == 0
+            _push!(target, source.configs[i])
+        end
+    end
+end

--- a/src/configurations.jl
+++ b/src/configurations.jl
@@ -47,16 +47,18 @@ decompress(mc, model, conf) = conf
 
 function _save(file::JLDFile, cs::ConfigRecorder, entryname::String="configs")
     write(file, entryname * "/VERSION", 1)
+    write(file, entryname * "/tag", "ConfigRecorder")
     write(file, entryname * "/type", typeof(cs))
     write(file, entryname * "/data", cs.configs)
     write(file, entryname * "/rate", cs.rate)
 end
-function _load(data, ::Type{T}) where T <: ConfigRecorder
+function _load(data, ::Val{:ConfigRecorder})
     if !(data["VERSION"] == 1)
         throw(ErrorException("Failed to load $T version $(data["VERSION"])"))
     end
     data["type"](data["data"], data["rate"])
 end
+to_tag(::Type{<: ConfigRecorder}) = Val(:ConfigRecorder)
 
 
 
@@ -83,6 +85,7 @@ Base.iterate(c::Discarder, i=1) = nothing
 
 function _save(file::JLDFile, ::Discarder, entryname::String="configs")
     write(file, entryname * "/VERSION", 1)
-    write(file, entryname * "/type", Discarder)
+    write(file, entryname * "/tag", "Discarder")
 end
-_load(data, ::Type{Discarder}) = Discarder()
+_load(data, ::Val{:Discarder}) = Discarder()
+to_tag(::Type{<: Discarder}) = Val(:Discarder)

--- a/src/flavors/DQMC/DQMC.jl
+++ b/src/flavors/DQMC/DQMC.jl
@@ -83,22 +83,6 @@ Create a determinant quantum Monte Carlo simulation for model `m` with
 DQMC(m::Model, params::Dict{Symbol}) = DQMC(m; params...)
 DQMC(m::Model, params::NamedTuple) = DQMC(m; params...)
 
-# Simplified constructor
-function DQMC(
-        CB, model::M, conf::ConfType, temp_conf::ConfType, last_sweep,
-        stack::Stack, ut_stack::UTStack, scheduler::US,
-        parameters, analysis,
-        recorder::RT,
-        thermalization_measurements, measurements
-    ) where {M, ConfType, RT, Stack, UTStack, US}
-
-    DQMC{M, CB, ConfType, RT, Stack, UTStack, US}(
-        model, conf, temp_conf, last_sweep, stack, ut_stack, 
-        scheduler, parameters, analysis, recorder,
-        thermalization_measurements, measurements
-    )
-end
-
 # convenience
 @inline beta(mc::DQMC) = mc.parameters.beta
 @inline nslices(mc::DQMC) = mc.parameters.slices

--- a/src/flavors/DQMC/FileIO.jl
+++ b/src/flavors/DQMC/FileIO.jl
@@ -17,6 +17,7 @@ to_tag(::Type{<: MagnitudeStats}) = Val(:MagnitudeStats)
 function save_mc(file::JLDFile, mc::DQMC, entryname::String="DQMC")
     write(file, entryname * "/VERSION", 2)
     write(file, entryname * "/tag", "DQMC")
+    write(file, entryname * "/CB", mc isa DQMC_CBTrue)
     save_parameters(file, mc.parameters, entryname * "/Parameters")
     save_analysis(file, mc.analysis, entryname * "/Analysis")
     write(file, entryname * "/conf", mc.conf)
@@ -39,7 +40,9 @@ function _load(data, ::Val{:DQMC})
         throw(ErrorException("Failed to load DQMC version $(data["VERSION"])"))
     end
 
-    CB = CB_type(data["type"])
+    CB = if haskey(data, "CB")
+        data["CB"] ? CheckerboardTrue : CheckerboardFalse
+    else CB_type(data["type"]) end
     @assert CB <: Checkerboard
     parameters = _load(data["Parameters"], Val(:DQMCParameters))
     analysis = _load(data["Analysis"], Val(:DQMCAnalysis))

--- a/src/flavors/DQMC/FileIO.jl
+++ b/src/flavors/DQMC/FileIO.jl
@@ -2,6 +2,10 @@
 ### FileIO
 ################################################################################
 
+to_tag(::Type{<: DQMC}) = Val(:DQMC)
+to_tag(::Type{<: DQMCParameters}) = Val(:DQMCParameters)
+to_tag(::Type{<: DQMCAnalysis}) = Val(:DQMCAnalysis)
+to_tag(::Type{<: MagnitudeStats}) = Val(:MagnitudeStats)
 
 
 #     save_mc(filename, mc, entryname)
@@ -10,9 +14,9 @@
 # JLD-file `filename` under group `entryname`.
 #
 # When saving a simulation the default `entryname` is `MC`
-function save_mc(file::JLDFile, mc::DQMC, entryname::String="MC")
+function save_mc(file::JLDFile, mc::DQMC, entryname::String="DQMC")
     write(file, entryname * "/VERSION", 2)
-    write(file, entryname * "/type", typeof(mc))
+    write(file, entryname * "/tag", "DQMC")
     save_parameters(file, mc.parameters, entryname * "/Parameters")
     save_analysis(file, mc.analysis, entryname * "/Analysis")
     write(file, entryname * "/conf", mc.conf)
@@ -30,21 +34,21 @@ CB_type(T::DataType) = T.parameters[2]
 #     load_mc(data, ::Type{<: DQMC})
 #
 # Loads a DQMC from a given `data` dictionary produced by `JLD.load(filename)`.
-function _load(data, ::Type{T}) where T <: DQMC
+function _load(data, ::Val{:DQMC})
     if data["VERSION"] > 2
-        throw(ErrorException("Failed to load $T version $(data["VERSION"])"))
+        throw(ErrorException("Failed to load DQMC version $(data["VERSION"])"))
     end
 
     CB = CB_type(data["type"])
     @assert CB <: Checkerboard
-    parameters = _load(data["Parameters"], data["Parameters"]["type"])
-    analysis = _load(data["Analysis"], data["Analysis"]["type"])
+    parameters = _load(data["Parameters"], Val(:DQMCParameters))
+    analysis = _load(data["Analysis"], Val(:DQMCAnalysis))
     conf = data["conf"]
-    recorder = _load(data["configs"], data["configs"]["type"])
+    recorder = _load(data["configs"], to_tag(data["configs"]))
     last_sweep = data["last_sweep"]
-    model = _load(data["Model"], data["Model"]["type"])
+    model = _load(data["Model"], to_tag(data["Model"]))
     scheduler = if haskey(data, "Scheduler")
-        _load(data["Scheduler"], data["Scheduler"]["type"])
+        _load(data["Scheduler"], to_tag(data["Scheduler"]))
     else
         if haskey(data["Parameters"], "global_moves") && Bool(data["Parameters"]["global_moves"])
             rate = get(data["Parameters"], "global_rate", 10)
@@ -55,7 +59,7 @@ function _load(data, ::Type{T}) where T <: DQMC
         end
     end
 
-    combined_measurements = _load(data["Measurements"], Measurements)
+    combined_measurements = _load(data["Measurements"], Val(:Measurements))
     thermalization_measurements = combined_measurements[:TH]
     measurements = combined_measurements[:ME]
 
@@ -84,7 +88,7 @@ end
 # When saving a simulation the default `entryname` is `MC/Parameters`
 function save_parameters(file::JLDFile, p::DQMCParameters, entryname::String="Parameters")
     write(file, entryname * "/VERSION", 1)
-    write(file, entryname * "/type", typeof(p))
+    write(file, entryname * "/tag", "DQMCParameters")
 
     write(file, entryname * "/thermalization", p.thermalization)
     write(file, entryname * "/sweeps", p.sweeps)
@@ -105,21 +109,24 @@ end
 #
 # Loads a DQMCParameters object from a given `data` dictionary produced by
 # `JLD.load(filename)`.
-function _load(data, ::Type{T}) where T <: DQMCParameters
+function _load(data, ::Val{:DQMCParameters})
     if !(data["VERSION"] == 1)
-        throw(ErrorException("Failed to load $T version $(data["VERSION"])"))
+        throw(ErrorException("Failed to load DQMCParameters version $(data["VERSION"])"))
     end
 
-    data["type"](
+    DQMCParameters(
         data["thermalization"],
         data["sweeps"],
+
         Bool(data["silent"]),
         Bool(data["check_sign_problem"]),
         Bool(data["check_propagation_error"]),
+
         data["safe_mult"],
         data["delta_tau"],
         data["beta"],
         data["slices"],
+
         data["measure_rate"],
         haskey(data, "print_rate") ? data["print_rate"] : 10,
     )
@@ -142,17 +149,17 @@ function save_stats(file::JLDFile, ms::MagnitudeStats, entryname::String="MStats
     write(file, entryname * "/count", ms.count)
 end
 
-function _load(data, ::Type{T}) where T <: DQMCAnalysis
+function _load(data, ::Val{:DQMCAnalysis})
     if !(data["VERSION"] == 1)
-        throw(ErrorException("Failed to load $T version $(data["VERSION"])"))
+        throw(ErrorException("Failed to load DQMCAnalysis version $(data["VERSION"])"))
     end
 
-    data["type"](
+    DQMCAnalysis(
         th_runtime = get(data, "th_runtime", 0.0),
         me_runtime = get(data, "me_runtime", 0.0),
         imaginary_probability = load_stats(data["imag_prob"]),
-        negative_probability = load_stats(data["neg_prob"]),
-        propagation_error = load_stats(data["propagation"])
+        negative_probability  = load_stats(data["neg_prob"]),
+        propagation_error     = load_stats(data["propagation"])
     )
 end
 function load_stats(data)

--- a/src/flavors/DQMC/main.jl
+++ b/src/flavors/DQMC/main.jl
@@ -53,6 +53,42 @@ mutable struct DQMC{
     end
 end
 
+# Simplified constructor
+function DQMC(
+        CB, model::M, conf::ConfType, temp_conf::ConfType, last_sweep,
+        stack::Stack, ut_stack::UTStack, scheduler::US,
+        parameters, analysis,
+        recorder::RT,
+        thermalization_measurements, measurements
+    ) where {M, ConfType, RT, Stack, UTStack, US}
+
+    DQMC{M, CB, ConfType, RT, Stack, UTStack, US}(
+        model, conf, temp_conf, last_sweep, stack, ut_stack, 
+        scheduler, parameters, analysis, recorder,
+        thermalization_measurements, measurements
+    )
+end
+
+
+# copy constructor
+function DQMC(
+        mc::DQMC{x, CBT};
+        CB = CBT, model::M = mc.model, conf::ConfType = mc.conf, 
+        temp_conf::ConfType = mc.conf, last_sweep = mc.last_sweep,
+        stack::Stack = mc.stack, ut_stack::UTStack = mc.ut_stack, 
+        scheduler::US = mc.scheduler, parameters = mc.parameters, 
+        analysis = mc.analysis, recorder::RT = mc.recorder,
+        thermalization_measurements = mc.thermalization_measurements, 
+        measurements = mc.measurements
+    ) where {x, CBT, M, ConfType, RT, Stack, UTStack, US}
+
+    DQMC{M, CB, ConfType, RT, Stack, UTStack, US}(
+        model, conf, temp_conf, last_sweep, stack, ut_stack, 
+        scheduler, parameters, analysis, recorder,
+        thermalization_measurements, measurements
+    )
+end
+
 
 # Contains `DQMCStack`, `propagate` and related functions. The stack keeps track
 # of all the matrices that go into calculating the path integral. `propagate` 

--- a/src/flavors/DQMC/main.jl
+++ b/src/flavors/DQMC/main.jl
@@ -25,13 +25,13 @@ mutable struct DQMC{
     temp_conf::ConfType
     last_sweep::Int
 
-    stack::Stack # s -> stack 
+    stack::Stack
     ut_stack::UTStack
     scheduler::US
-    parameters::DQMCParameters # p -> parameters
-    analysis::DQMCAnalysis # a -> analysis
+    parameters::DQMCParameters
+    analysis::DQMCAnalysis
 
-    recorder::RT # configs -> recorder
+    recorder::RT
     thermalization_measurements::Dict{Symbol, AbstractMeasurement}
     measurements::Dict{Symbol, AbstractMeasurement}
 

--- a/src/flavors/DQMC/measurements/generic.jl
+++ b/src/flavors/DQMC/measurements/generic.jl
@@ -210,7 +210,7 @@ lattice_iterator(m::DQMCMeasurement, mc, model) = m.lattice_iterator(mc, model)
 # break stuff this way
 function _save(file::JLDFile, m::DQMCMeasurement, key::String)
     write(file, "$key/VERSION", 1)
-    write(file, "$key/type", DQMCMeasurement)
+    write(file, "$key/tag", "DQMCMeasurement")
     write(file, "$key/GI", m.greens_iterator)
     write(file, "$key/LI", m.lattice_iterator)
     # maybe add module for eval?
@@ -219,7 +219,7 @@ function _save(file::JLDFile, m::DQMCMeasurement, key::String)
     write(file, "$key/temp", m.temp)
 end
 
-function _load(data, ::Type{T}) where {T <: DQMCMeasurement}
+function _load(data, ::Val{:DQMCMeasurement})
     temp = haskey(data, "temp") ? data["temp"] : data["output"]
     
     kernel = try
@@ -230,6 +230,8 @@ function _load(data, ::Type{T}) where {T <: DQMCMeasurement}
     end
     DQMCMeasurement(data["GI"], data["LI"], kernel, data["obs"], temp)
 end
+
+to_tag(::Type{<: DQMCMeasurement}) = Val(:DQMCMeasurement)
 
 
 ################################################################################

--- a/src/flavors/DQMC/updates/scheduler.jl
+++ b/src/flavors/DQMC/updates/scheduler.jl
@@ -202,14 +202,16 @@ end
 
 function save_scheduler(file::JLDFile, s::SimpleScheduler, entryname::String="/Scheduler")
     write(file, entryname * "/VERSION", 1)
-    write(file, entryname * "/type", typeof(s))
+    write(file, entryname * "/tag", "SimpleScheduler")
     write(file, entryname * "/sequence", s.sequence)
     write(file, entryname * "/idx", s.idx)
     nothing
 end
-function _load(data, ::Type{<: SimpleScheduler})
+function _load(data, ::Val{:SimpleScheduler})
     SimpleScheduler(data["sequence"], data["idx"])
 end
+
+to_tag(::Type{<: SimpleScheduler}) = Val(:SimpleScheduler)
 
 
 
@@ -389,7 +391,7 @@ end
 
 function save_scheduler(file::JLDFile, s::AdaptiveScheduler, entryname::String="/Scheduler")
     write(file, entryname * "/VERSION", 1)
-    write(file, entryname * "/type", typeof(s))
+    write(file, entryname * "/tag", "AdaptiveScheduler")
     write(file, entryname * "/sequence", s.sequence)
     write(file, entryname * "/sampling_rates", s.sampling_rates)
     write(file, entryname * "/pool", s.adaptive_pool)
@@ -399,7 +401,7 @@ function save_scheduler(file::JLDFile, s::AdaptiveScheduler, entryname::String="
     write(file, entryname * "/idx", s.idx)
     nothing
 end
-function _load(data, ::Type{<: AdaptiveScheduler})
+function _load(data, ::Val{:AdaptiveScheduler})
     s = AdaptiveScheduler(data["sequence"], data["pool"])
     s.sampling_rates = data["sampling_rates"]
     s.minimum_sampling_rate = data["minimum_sampling_rate"]
@@ -408,6 +410,9 @@ function _load(data, ::Type{<: AdaptiveScheduler})
     s.idx = data["idx"]
     s
 end
+
+to_tag(::Type{<: AdaptiveScheduler}) = Val(:AdaptiveScheduler)
+
 
 updates(s::AdaptiveScheduler) = (s.sequence..., s.adaptive_pool...)
 

--- a/src/flavors/MC/MC.jl
+++ b/src/flavors/MC/MC.jl
@@ -39,6 +39,9 @@ mutable struct MC{M<:Model, C, RT<:AbstractRecorder} <: MonteCarloFlavor
     a::MCAnalysis
 
     MC{M,C,RT}() where {M,C,RT} = new()
+    function MC(m::M, c::C, cs::RT, ls, tm, mm, p, a) where {M, C, RT}
+        new{M, C, RT}(m, c, cs, ls, tm, mm, p, a)
+    end
 end
 
 

--- a/src/lattices/LatPhys.jl
+++ b/src/lattices/LatPhys.jl
@@ -85,7 +85,7 @@ end
 
 function save_lattice(file::JLDFile, lattice::LatPhysLattice, entryname::String)
     write(file, entryname * "/VERSION", 0)
-    write(file, entryname * "/type", typeof(lattice))
+    write(file, entryname * "/tag", "LatPhysLattice")
     _save_lattice(file, lattice.lattice, entryname * "/lattice")
     write(file, entryname * "/neighs", lattice.neighs)
     nothing
@@ -127,9 +127,9 @@ function save_unitcell(file::JLDFile, uc::LatPhysBase.AbstractUnitcell, entrynam
 end
 
 
-function _load(data, ::Type{T}) where T <: LatPhysLattice
+function _load(data, ::Val{:LatPhysLattice})
     @assert data["VERSION"] == 0
-    data["type"](load_lattice(data["lattice"]), data["neighs"])
+    LatPhysLattice(load_lattice(data["lattice"]), data["neighs"])
 end
 function load_lattice(data)
     sites = load_sites(data["sites"])
@@ -148,6 +148,7 @@ end
 load_sites(data) = data["type"].(data["points"], data["labels"])
 load_bonds(data) = data["type"].(data["froms"], data["tos"], data["labels"], data["wraps"])
 
+to_tag(::Type{<: LatPhysLattice}) = Val(:LatPhysLattice)
 
 
 ################################################################################

--- a/src/linalg/blockdiagonal.jl
+++ b/src/linalg/blockdiagonal.jl
@@ -225,7 +225,7 @@ function vmul!(C::BlockDiagonal{T, N}, X::Adjoint{T}, B::BlockDiagonal{T, N}) wh
         end
     end
 end
-function vmul!(C::BD, X1::Transpose{T, BD}, X2::Transpose{T, BD}) where {T <: Real, N, BD <: BlockDiagonal{T, N}}
+function vmul!(C::BD, X1::Adjoint{T, BD}, X2::Adjoint{T, BD}) where {T <: Real, N, BD <: BlockDiagonal{T, N}}
     A = X1.parent
     B = X2.parent
     @inbounds n = size(C.blocks[1], 1)

--- a/src/linalg/general.jl
+++ b/src/linalg/general.jl
@@ -43,7 +43,7 @@ function vmul!(C::Matrix{T}, X::Adjoint{T}, B::Matrix{T}) where {T <: Real}
         C[m,n] = Cmn
     end
 end
-function vmul!(C::Matrix{T}, X1::Transpose{T}, X2::Transpose{T}) where {T <: Real}
+function vmul!(C::Matrix{T}, X1::Adjoint{T}, X2::Adjoint{T}) where {T <: Real}
     A = X1.parent
     B = X2.parent
     @turbo for m in 1:size(A, 1), n in 1:size(B, 2)

--- a/src/models/HubbardModel/HubbardModelAttractive.jl
+++ b/src/models/HubbardModel/HubbardModelAttractive.jl
@@ -218,7 +218,7 @@ function save_model(
         entryname::String="Model"
     )
     write(file, entryname * "/VERSION", 1)
-    write(file, entryname * "/type", typeof(m))
+    write(file, entryname * "/tag", "HubbardModelAttractive")
 
     write(file, entryname * "/mu", m.mu)
     write(file, entryname * "/U", m.U)
@@ -233,13 +233,13 @@ end
 #
 # Loads a DQMCParameters object from a given `data` dictionary produced by
 # `JLD.load(filename)`.
-function _load(data, ::Type{T}) where T <: HubbardModelAttractive
+function _load(data, ::Val{:HubbardModelAttractive})
     if !(data["VERSION"] == 1)
         throw(ErrorException("Failed to load HubbardModelAttractive version $(data["VERSION"])"))
     end
 
-    l = _load(data["l"], data["l"]["type"])
-    data["type"](
+    l = _load(data["l"], to_tag(data["l"]))
+    HubbardModelAttractive(
         mu = data["mu"],
         U = data["U"],
         t = data["t"],
@@ -247,7 +247,7 @@ function _load(data, ::Type{T}) where T <: HubbardModelAttractive
         flv = data["flv"]
     )
 end
-
+to_tag(::Type{<: HubbardModelAttractive}) = Val(:HubbardModelAttractive)
 
 
 ################################################################################

--- a/src/models/HubbardModel/HubbardModelRepulsive.jl
+++ b/src/models/HubbardModel/HubbardModelRepulsive.jl
@@ -245,7 +245,7 @@ function save_model(
         entryname::String="Model"
     )
     write(file, entryname * "/VERSION", 1)
-    write(file, entryname * "/type", typeof(m))
+    write(file, entryname * "/tag", "HubbardModelRepulsive")
 
     write(file, entryname * "/U", m.U)
     write(file, entryname * "/t", m.t)
@@ -259,19 +259,20 @@ end
 #
 # Loads a DQMCParameters object from a given `data` dictionary produced by
 # `JLD.load(filename)`.
-function _load(data, ::Type{T}) where T <: HubbardModelRepulsive
+function _load(data, ::Val{:HubbardModelRepulsive})
     if !(data["VERSION"] == 1)
         throw(ErrorException("Failed to load HubbardModelRepulsive version $(data["VERSION"])"))
     end
 
-    l = _load(data["l"], data["l"]["type"])
-    data["type"](
+    l = _load(data["l"], to_tag(data["l"]))
+    HubbardModelRepulsive(
         U = data["U"],
         t = data["t"],
         l = l,
         flv = data["flv"]
     )
 end
+to_tag(::Type{<: HubbardModelRepulsive}) = Val(:HubbardModelRepulsive)
 
 
 

--- a/src/models/Ising/IsingModel.jl
+++ b/src/models/Ising/IsingModel.jl
@@ -192,7 +192,7 @@ function save_model(
         entryname::String="Model"
     )
     write(file, entryname * "/VERSION", 1)
-    write(file, entryname * "/type", typeof(m))
+    write(file, entryname * "/tag", "IsingModel")
 
     write(file, entryname * "/L", m.L)
     write(file, entryname * "/dims", m.dims)
@@ -205,13 +205,13 @@ end
 #
 # Loads an IsingModel from a given `data` dictionary produced by
 # `JLD.load(filename)`.
-function _load(data, ::Type{T}) where T <: IsingModel
+function _load(data, ::Val{:IsingModel})
     if !(data["VERSION"] == 1)
         throw(ErrorException("Failed to load IsingModel version $(data["VERSION"])"))
     end
 
-    l = _load(data["l"], data["l"]["type"])
-    model = data["type"](
+    l = _load(data["l"], to_tag(data["l"]))
+    model = IsingModel(
         L = data["L"],
         dims = data["dims"],
         l = l
@@ -219,6 +219,7 @@ function _load(data, ::Type{T}) where T <: IsingModel
     model.energy[] = data["energy"]
     model
 end
+to_tag(::Type{<: IsingModel}) = Val(:IsingModel)
 
 
 

--- a/test/FileIO.jl
+++ b/test/FileIO.jl
@@ -76,6 +76,21 @@
     @test r.buffer[1] == c2 # this would fail if chunk not loaded
     @test r.buffer[2] == c3
     @test r.buffer[3] == c
+
+    # test merge!
+    c4 = rand(4, 4)
+    cs = ConfigRecorder{Matrix{Float64}}([c4 for _ in 1:17], 10)
+    merge!(r, cs)
+
+    @test r.idx == 20
+    @test r.chunk == 2
+    @test r.total_length == 39
+    @test r.save_idx == 21
+    @test r.buffer[1] == c2   # old
+    @test r.buffer[2] == c3   # old
+    @test r.buffer[3] == c4   # new
+    @test r.buffer[19] == c4  # new
+    @test r.buffer[20] == c   # to be overwritten
     rm("testfile.confs")
 end
 

--- a/test/flavortests_DQMC.jl
+++ b/test/flavortests_DQMC.jl
@@ -49,7 +49,7 @@ end
 @testset "DQMC utilities " begin
     m = HubbardModelAttractive(8, 1);
 
-    # constructors
+    # Getters
     dqmc = DQMC(m; beta=5.0)
 
     @test MonteCarlo.beta(dqmc) == dqmc.parameters.beta
@@ -82,6 +82,50 @@ end
     @test MonteCarlo.init_interaction_matrix(m) == zeros(ComplexF64, 8, 8)
     @test_throws MethodError MonteCarlo.energy_boson(dqmc, m, MonteCarlo.conf(dqmc))
     @test parameters(m) == NamedTuple()
+
+    # constructors
+    mc = DQMC{
+        typeof(dqmc.model), MonteCarlo.CheckerboardFalse, typeof(dqmc.conf),
+        typeof(dqmc.recorder), typeof(dqmc.stack), typeof(dqmc.ut_stack), 
+        typeof(dqmc.scheduler)
+    }(
+        dqmc.model, dqmc.conf, dqmc.temp_conf, dqmc.last_sweep, dqmc.stack, 
+        dqmc.ut_stack, dqmc.scheduler, dqmc.parameters, dqmc.analysis, 
+        dqmc.recorder, dqmc.thermalization_measurements, dqmc.measurements
+    )
+    for field in fieldnames(mc)
+        @test getfield(dqmc, field) == getfield(mc, field)
+    end
+
+    mc = DQMC(
+        dqmc.model, dqmc.conf, dqmc.temp_conf, dqmc.last_sweep, dqmc.stack, 
+        dqmc.ut_stack, dqmc.scheduler, dqmc.parameters, dqmc.analysis, 
+        dqmc.recorder, dqmc.thermalization_measurements, dqmc.measurements
+    )
+    for field in fieldnames(mc)
+        @test getfield(dqmc, field) == getfield(mc, field)
+    end
+
+    mc = DQMC(dqmc)
+    for field in fieldnames(mc)
+        @test getfield(dqmc, field) == getfield(mc, field)
+    end
+
+    mc = DQMC(dqmc, last_sweep = 9147, recorder = Discarder())
+    for field in fieldnames(mc)
+        if field == :last_sweep 
+            @test mc.last_sweep = 9147
+        elseif field == :recorder
+            @test mc.recorder isa Discarder
+        else
+            @test getfield(dqmc, field) == getfield(mc, field)
+        end
+    end
+    @test mc isa DQMC{
+        typeof(dqmc.model), MonteCarlo.CheckerboardFalse, typeof(dqmc.conf),
+        Discarder, typeof(dqmc.stack), typeof(dqmc.ut_stack), 
+        typeof(dqmc.scheduler)
+    }
 end
 
 

--- a/test/flavortests_DQMC.jl
+++ b/test/flavortests_DQMC.jl
@@ -93,7 +93,7 @@ end
         dqmc.ut_stack, dqmc.scheduler, dqmc.parameters, dqmc.analysis, 
         dqmc.recorder, dqmc.thermalization_measurements, dqmc.measurements
     )
-    for field in fieldnames(mc)
+    for field in fieldnames(DQMC)
         @test getfield(dqmc, field) == getfield(mc, field)
     end
 
@@ -102,17 +102,17 @@ end
         dqmc.ut_stack, dqmc.scheduler, dqmc.parameters, dqmc.analysis, 
         dqmc.recorder, dqmc.thermalization_measurements, dqmc.measurements
     )
-    for field in fieldnames(mc)
+    for field in fieldnames(DQMC)
         @test getfield(dqmc, field) == getfield(mc, field)
     end
 
     mc = DQMC(dqmc)
-    for field in fieldnames(mc)
+    for field in fieldnames(DQMC)
         @test getfield(dqmc, field) == getfield(mc, field)
     end
 
     mc = DQMC(dqmc, last_sweep = 9147, recorder = Discarder())
-    for field in fieldnames(mc)
+    for field in fieldnames(DQMC)
         if field == :last_sweep 
             @test mc.last_sweep = 9147
         elseif field == :recorder

--- a/test/flavortests_DQMC.jl
+++ b/test/flavortests_DQMC.jl
@@ -115,7 +115,7 @@ end
     mc = DQMC(dqmc, last_sweep = 9147, recorder = Discarder())
     for field in fieldnames(DQMC)
         if field == :last_sweep 
-            @test mc.last_sweep = 9147
+            @test mc.last_sweep == 9147
         elseif field == :recorder
             @test mc.recorder isa Discarder
         else

--- a/test/flavortests_DQMC.jl
+++ b/test/flavortests_DQMC.jl
@@ -98,9 +98,10 @@ end
     end
 
     mc = DQMC(
-        dqmc.model, dqmc.conf, dqmc.temp_conf, dqmc.last_sweep, dqmc.stack, 
-        dqmc.ut_stack, dqmc.scheduler, dqmc.parameters, dqmc.analysis, 
-        dqmc.recorder, dqmc.thermalization_measurements, dqmc.measurements
+        MonteCarlo.CheckerboardFalse, dqmc.model, dqmc.conf, dqmc.temp_conf, 
+        dqmc.last_sweep, dqmc.stack, dqmc.ut_stack, dqmc.scheduler, 
+        dqmc.parameters, dqmc.analysis, dqmc.recorder, 
+        dqmc.thermalization_measurements, dqmc.measurements
     )
     for field in fieldnames(DQMC)
         @test getfield(dqmc, field) == getfield(mc, field)

--- a/test/slice_matrices.jl
+++ b/test/slice_matrices.jl
@@ -156,6 +156,9 @@ using MonteCarlo: BlockDiagonal#, CMat64, CVec64, StructArray
             vmul!(C, A', B)
             @test A' * B ≈ C atol = atol
 
+            vmul!(C, A', B')
+            @test A' * B' ≈ C atol = atol
+
             D = Diagonal(rand(16))
             vmul!(C, A, D)
             @test A * D ≈ C atol = atol
@@ -357,6 +360,19 @@ using MonteCarlo: BlockDiagonal#, CMat64, CVec64, StructArray
 
         vsub!(B1, B2, I)
         @test M2 - I ≈ B1 atol = atol
+
+        x = rand()
+        @test B2 * x ≈ M2 * x atol = atol
+
+        @test log(B2) ≈ log(M2) atol = atol
+
+        @test det(B2) ≈ det(M2) atol = atol
+
+        transpose!(B1, B2)
+        @test B1 ≈ M2' atol = atol
+
+        vmul!(B1, B2', B3')
+        @test B1 ≈ M2' * M3' atol = atol
 
         # Test UDT and rdivp!
         M2 = Matrix(B2)


### PR DESCRIPTION
### TODO
- [x] #89
- [x] #124 (via `BufferedConfigRecorder` which should probably replace the normal one but that'd be breaking?)
- [x] add a buffered config recorder (or replace the existing one) (i.e. in-memory buffer that gets cleared when it's full/loads the next chunk when needed)

closes #89 
closes #124 