### PR TITLE
increment sweeps on every full update

### DIFF
--- a/src/flavors/DQMC/updates/local_updates.jl
+++ b/src/flavors/DQMC/updates/local_updates.jl
@@ -10,7 +10,6 @@ function local_sweep(mc::DQMC, model)
         accepted += sweep_spatial(mc, model)
         propagate(mc)
     end
-    mc.last_sweep += 1
     return accepted
 end
 

--- a/test/updates.jl
+++ b/test/updates.jl
@@ -58,23 +58,20 @@ MonteCarlo.update(::GoodUpdate, args...) = 1.0
         @test mc.scheduler.idx == 0
         @test mc.last_sweep == 0
 
-        accepted = MonteCarlo.update(mc.scheduler, mc, mc.model)
+        MonteCarlo.update(mc.scheduler, mc, mc.model)
         @test mc.scheduler.sequence[1].total == 1
-        @test mc.scheduler.sequence[1].accepted == accepted
         @test mc.scheduler.idx == 1
         @test mc.last_sweep == 1
         
-        accepted = MonteCarlo.update(mc.scheduler, mc, mc.model)
+        MonteCarlo.update(mc.scheduler, mc, mc.model)
         @test mc.scheduler.sequence[2].total == 1
-        @test mc.scheduler.sequence[2].accepted == accepted
         @test mc.scheduler.idx == 2
-        @test mc.last_sweep == 1
-
-        accepted = MonteCarlo.update(mc.scheduler, mc, mc.model)
-        @test mc.scheduler.sequence[3].total == 1
-        @test mc.scheduler.sequence[3].accepted == accepted
-        @test mc.scheduler.idx == 3
         @test mc.last_sweep == 2
+
+        MonteCarlo.update(mc.scheduler, mc, mc.model)
+        @test mc.scheduler.sequence[3].total == 1
+        @test mc.scheduler.idx == 3
+        @test mc.last_sweep == 3
     end
 
     schedulers = (


### PR DESCRIPTION
Adjusts scheduler to run updates until one that is equivalent to a full sweep (i.e. not NoUpdate) and then increments the sweep counter.

closes #131