### PR TITLE
Extend and cleanup ED tests

### DIFF
--- a/test/ED/ED_tests.jl
+++ b/test/ED/ED_tests.jl
@@ -165,7 +165,7 @@ end
             # G = I - U * inv(I + D) * adjoint(U)
             G = U * inv(I + D) * adjoint(U)
         
-            print("    Running ED and checking (tolerance: $atol, $rtol%)\n    ")
+            print("    Running ED and checking (tolerance: $atol, $(100rtol)%)\n    ")
             @time begin
                 H = HamiltonMatrix(model)
 
@@ -465,7 +465,7 @@ end
             rtol = 2dqmc.parameters.delta_tau^2
             N = length(lattice(model))
         
-            print("    Running ED and checking (tolerance: $atol, $rtol%)\n    ")
+            print("    Running ED and checking (tolerance: $atol, $(100rtol)%)\n    ")
             @time begin
                 H = HamiltonMatrix(model)
 

--- a/test/ED/ED_tests.jl
+++ b/test/ED/ED_tests.jl
@@ -107,7 +107,7 @@ end
         HubbardModelAttractive(2, 2, U = 0.0, mu = 1.0, t = 1.0)
     )
 
-    @info "Exact Greens comparison (ED)"
+    println("Exact Greens comparison (ED)")
     for model in models, beta in (1.0, 10.0)
         @testset "$(typeof(model))" begin
             Random.seed!(123)
@@ -115,7 +115,7 @@ end
                 model, beta=beta, delta_tau = 0.1, safe_mult=5, recorder = Discarder(), 
                 thermalization = 1, sweeps = 2, measure_rate=1
             )
-            @info "Running DQMC ($(typeof(model).name)) β=$(dqmc.parameters.beta)"
+            print("  Running DQMC ($(typeof(model).name.name)) β=$(dqmc.parameters.beta) in ")
 
             dqmc[:G]    = greens_measurement(dqmc, model)
             dqmc[:E]    = total_energy(dqmc, model)
@@ -160,7 +160,7 @@ end
             # G = I - U * inv(I + D) * adjoint(U)
             G = U * inv(I + D) * adjoint(U)
         
-            @info "Running ED"
+            print("    Running ED and checking in ")
             @time begin
                 H = HamiltonMatrix(model)
 
@@ -392,6 +392,7 @@ end
         HubbardModelAttractive(2, 2, U = 1.0, mu = 1.0, t = 1.0)
     )
 
+    println("Finite U ED Comparison")
     for model in models
         @testset "$(typeof(model))" begin
             Random.seed!(123)
@@ -402,7 +403,10 @@ end
                 #     (LocalSweep(10), Adaptive(),), (GlobalShuffle(), GlobalFlip())
                 # )
             )
-            @info "Running DQMC ($(typeof(model).name)) β=$(dqmc.parameters.beta), 10k + 10k sweeps"
+            print(
+                "  Running DQMC ($(typeof(model).name.name)) " * 
+                "β=$(dqmc.parameters.beta), 10k + 10k sweeps in "
+            )
 
             dqmc[:G]    = greens_measurement(dqmc, model)
             dqmc[:E]    = total_energy(dqmc, model)
@@ -444,7 +448,7 @@ end
             rtol = 2dqmc.parameters.delta_tau^2
             N = length(lattice(model))
         
-            @info "Running ED"
+            print("    Running ED and checking in ")
             @time begin
                 H = HamiltonMatrix(model)
 

--- a/test/ED/ED_tests.jl
+++ b/test/ED/ED_tests.jl
@@ -2,6 +2,11 @@ using Random
 include("ED.jl")
 
 
+################################################################################
+### Verify ED
+################################################################################
+
+
 @testset "ED checks" begin
     void = State(0)
     up = State(1)
@@ -89,6 +94,11 @@ include("ED.jl")
 end
 
 
+################################################################################
+### Checks with U = 0 (should be numerically exact)
+################################################################################
+
+
 @testset "Exact Greens comparison (ED, tiny systems)" begin
     # These are theoretically the same but their implementation differs on
     # some level. To make sure both are correct it makes sense to check both here.
@@ -108,12 +118,32 @@ end
             @info "Running DQMC ($(typeof(model).name)) β=$(dqmc.parameters.beta)"
 
             dqmc[:G]    = greens_measurement(dqmc, model)
+            dqmc[:E]    = total_energy(dqmc, model)
+            dqmc[:Occs] = occupation(dqmc, model)
+            dqmc[:CDC]  = charge_density_correlation(dqmc, model)
+            dqmc[:Mx]   = magnetization(dqmc, model, :x)
+            dqmc[:My]   = magnetization(dqmc, model, :y)
+            dqmc[:Mz]   = magnetization(dqmc, model, :z)
+            dqmc[:SDCx] = spin_density_correlation(dqmc, model, :x)
+            dqmc[:SDCy] = spin_density_correlation(dqmc, model, :y)
+            dqmc[:SDCz] = spin_density_correlation(dqmc, model, :z)
+            dqmc[:PC]   = pairing_correlation(dqmc, model, lattice_iterator = EachLocalQuadByDistance(1:4))
+
+            # Unequal time
             l1s = [0, 3, 5, 7, 3, 0, MonteCarlo.nslices(dqmc), 0]
             l2s = [1, 7, 5, 2, 1, MonteCarlo.nslices(dqmc), 0, 0]
             for i in eachindex(l1s)
                 dqmc[Symbol(:UTG, i)] = greens_measurement(dqmc, model, GreensAt(l2s[i], l1s[i]))
             end
 
+            dqmc[:CDS]  = charge_density_susceptibility(dqmc, model)
+            dqmc[:SDSx] = spin_density_susceptibility(dqmc, model, :x)
+            dqmc[:SDSy] = spin_density_susceptibility(dqmc, model, :y)
+            dqmc[:SDSz] = spin_density_susceptibility(dqmc, model, :z)
+            dqmc[:PS]   = pairing_susceptibility(dqmc, model, lattice_iterator = EachLocalQuadByDistance(1:4))
+            dqmc[:CCS]  = current_current_susceptibility(dqmc, model, lattice_iterator = EachLocalQuadBySyncedDistance(1:4))
+
+            
             @time run!(dqmc, verbose=false)
             
             # error tolerance
@@ -133,6 +163,12 @@ end
             @info "Running ED"
             @time begin
                 H = HamiltonMatrix(model)
+
+                @testset "(total) energy" begin
+                    dqmc_E = mean(dqmc[:E])
+                    ED_E = energy(H, beta = dqmc.parameters.beta)
+                    @test dqmc_E ≈ ED_E atol=atol rtol=rtol
+                end
             
                 # G_DQMC is smaller because it doesn't differentiate between spin up/down
                 @testset "Greens" begin
@@ -143,22 +179,211 @@ end
                     @test check(G_DQMC, G, atol, rtol)
                 end
 
-                for (i, tau1, tau2) in zip(eachindex(l1s), 0.1l1s, 0.1l2s)
-                    UTG = mean(dqmc.measurements[Symbol(:UTG, i)])
-                    M = size(UTG, 1)
-                    ED_UTG = calculate_Greens_matrix(H, tau2, tau1, model.l, beta=dqmc.parameters.beta)
 
-                    @testset "[$i] $tau1 -> $tau2" begin
-                        for k in 1:M, l in 1:M
-                            @test check(UTG[k, l], ED_UTG[k, l], atol, rtol)
+                @testset "Charge Density Correlation" begin
+                    CDC = mean(dqmc.measurements[:CDC])
+                    ED_CDC = zeros(size(CDC))
+                    for (dir, src, trg) in MonteCarlo.lattice_iterator(dqmc[:CDC], dqmc, model)
+                        ED_CDC[dir] += expectation_value(
+                            charge_density_correlation(trg, src),
+                            H, beta = dqmc.parameters.beta, N_sites = N
+                        )
+                    end
+                    @test check(ED_CDC/N, CDC, atol, rtol)
+                end
+
+                @testset "Magnetization x" begin
+                    Mx = mean(dqmc.measurements[:Mx])
+                    for site in 1:length(Mx)
+                        ED_Mx = expectation_value(
+                            m_x(site), H, beta = dqmc.parameters.beta, N_sites = N
+                        )
+                        @test check(ED_Mx, Mx[site], atol, rtol)
+                    end
+                end
+                @testset "Magnetization y" begin
+                    My = mean(dqmc.measurements[:My])
+                    for site in 1:length(My)
+                        ED_My = expectation_value(
+                            m_y(site), H, beta = dqmc.parameters.beta, N_sites = N
+                        ) |> imag
+                        @test check(ED_My, My[site], atol, rtol)
+                    end
+                end
+                @testset "Magnetization z" begin
+                    Mz = mean(dqmc.measurements[:Mz])
+                    for site in 1:length(Mz)
+                        ED_Mz = expectation_value(
+                            m_z(site), H, beta = dqmc.parameters.beta, N_sites = N
+                        )
+                        @test check(ED_Mz, Mz[site], atol, rtol)
+                    end
+                end
+
+                @testset "Spin density correlation x" begin
+                    SDCx = mean(dqmc.measurements[:SDCx])
+                    ED_SDCx = zeros(ComplexF64, size(SDCx))
+                    for (dir, src, trg) in MonteCarlo.lattice_iterator(dqmc[:SDCx], dqmc, model)
+                        ED_SDCx[dir] += expectation_value(
+                            spin_density_correlation_x(trg, src),
+                            H, beta = dqmc.parameters.beta, N_sites = N
+                        )
+                    end
+                    @test check(ED_SDCx/N, SDCx, atol, rtol)
+                end
+                @testset "Spin density correlation y" begin
+                    SDCy = mean(dqmc.measurements[:SDCy])
+                    ED_SDCy = zeros(ComplexF64, size(SDCy))
+                    for (dir, src, trg) in MonteCarlo.lattice_iterator(dqmc[:SDCy], dqmc, model)
+                        ED_SDCy[dir] += expectation_value(
+                            spin_density_correlation_y(trg, src),
+                            H, beta = dqmc.parameters.beta, N_sites = N
+                        )
+                    end
+                    @test check(ED_SDCy/N, SDCy, atol, rtol)
+                end
+                @testset "Spin density correlation z" begin
+                    SDCz = mean(dqmc.measurements[:SDCz])
+                    ED_SDCz = zeros(ComplexF64, size(SDCz))
+                    for (dir, src, trg) in MonteCarlo.lattice_iterator(dqmc[:SDCz], dqmc, model)
+                        ED_SDCz[dir] += expectation_value(
+                            spin_density_correlation_z(trg, src),
+                            H, beta = dqmc.parameters.beta, N_sites = N
+                        )
+                    end
+                    @test check(ED_SDCz/N, SDCz, atol, rtol)
+                end
+
+                @testset "Pairing Correlation" begin
+                    PC = mean(dqmc.measurements[:PC])
+                    ED_PC = zeros(ComplexF64, size(PC))
+                    for (dirs, src1, trg1, src2, trg2) in 
+                            MonteCarlo.EachLocalQuadByDistance{4}(dqmc, model)
+                        ED_PC[dirs] += expectation_value(
+                            pairing_correlation(src1, trg1, src2, trg2), 
+                            H, beta = dqmc.parameters.beta, N_sites = N
+                        )
+                    end
+                    @test check(ED_PC/N, PC, atol, rtol)
+                end
+
+                ################################################################
+                ### Unequal Time
+                ################################################################
+
+                @testset "Unequal Time Greens" begin
+                    for (i, tau1, tau2) in zip(eachindex(l1s), 0.1l1s, 0.1l2s)
+                        UTG = mean(dqmc.measurements[Symbol(:UTG, i)])
+                        M = size(UTG, 1)
+                        ED_UTG = calculate_Greens_matrix(H, tau2, tau1, model.l, beta=dqmc.parameters.beta)
+
+                        @testset "[$i] $tau1 -> $tau2" begin
+                            for k in 1:M, l in 1:M
+                                @test check(UTG[k, l], ED_UTG[k, l], atol, rtol)
+                            end
                         end
                     end
+                end
+
+                # CDC
+                @testset "Charge Density Susceptibility" begin
+                    CDS = mean(dqmc.measurements[:CDS])
+                    ED_CDS = zeros(size(CDS))
+                    for (dir, src, trg) in MonteCarlo.lattice_iterator(dqmc[:CDS], dqmc, model)
+                        ED_CDS[dir] += expectation_value_integrated(
+                            number_operator(trg), number_operator(src), H, 
+                            step = dqmc.parameters.delta_tau, beta = dqmc.parameters.beta, N_sites = N
+                        )
+                    end
+                    @test check(ED_CDS/N, CDS, atol, rtol)
+                end
+                
+                # SDS
+                @testset "Spin density Susceptibility x" begin
+                    SDSx = mean(dqmc.measurements[:SDSx])
+                    ED_SDSx = zeros(ComplexF64, size(SDSx))
+                    for (dir, src, trg) in MonteCarlo.lattice_iterator(dqmc[:SDSx], dqmc, model)
+                        ED_SDSx[dir] += expectation_value_integrated(
+                            m_x(trg), m_x(src), H, step = dqmc.parameters.delta_tau, 
+                            beta = dqmc.parameters.beta, N_sites = N
+                        )
+                    end
+                    @test check(ED_SDSx/N, SDSx, atol, rtol)
+                end
+                @testset "Spin density Susceptibility y" begin
+                    SDSy = mean(dqmc.measurements[:SDSy])
+                    ED_SDSy = zeros(ComplexF64, size(SDSy))
+                    for (dir, src, trg) in MonteCarlo.lattice_iterator(dqmc[:SDSy], dqmc, model)
+                        ED_SDSy[dir] += expectation_value_integrated(
+                            m_y(trg), m_y(src), H, step = dqmc.parameters.delta_tau, 
+                            beta = dqmc.parameters.beta, N_sites = N
+                        )
+                    end
+                    @test check(ED_SDSy/N, SDSy, atol, rtol)
+                end
+                @testset "Spin density Susceptibility z" begin
+                    SDSz = mean(dqmc.measurements[:SDSz])
+                    ED_SDSz = zeros(ComplexF64, size(SDSz))
+                    for (dir, src, trg) in MonteCarlo.lattice_iterator(dqmc[:SDSz], dqmc, model)
+                        ED_SDSz[dir] += expectation_value_integrated(
+                            m_z(trg), m_z(src), H, step = dqmc.parameters.delta_tau, 
+                            beta = dqmc.parameters.beta, N_sites = N
+                        )
+                    end
+                    @test check(ED_SDSz/N, SDSz, atol, rtol)
+                end
+
+                @testset "Pairing Susceptibility" begin
+                    PS = mean(dqmc.measurements[:PS])
+                    ED_PS = zeros(Float64, size(PS))
+                    for (dirs, src1, trg1, src2, trg2) in 
+                            MonteCarlo.EachLocalQuadByDistance{4}(dqmc, model)
+                        ED_PS[dirs] += expectation_value_integrated(
+                            state -> begin
+                                sign1, _state  = annihilate(state, trg1, DOWN)
+                                sign2, _state1 = annihilate(_state, src1, UP)
+                                sign3, _state  = create(state, src1, UP)
+                                sign4, _state2 = create(_state, trg1, DOWN)
+                                (sign1*sign2, sign3*sign4), (_state1, _state2)
+                            end,
+                            state -> begin
+                                sign1, _state  = create(state, src2, UP)
+                                sign2, _state1 = create(_state, trg2, DOWN)
+                                sign3, _state  = annihilate(state, trg2, DOWN)
+                                sign4, _state2 = annihilate(_state, src2, UP)
+                                (sign1*sign2, sign3*sign4), (_state1, _state2)
+                            end,
+                            H, step = dqmc.parameters.delta_tau, beta = dqmc.parameters.beta, N_sites = N
+                        )
+                    end
+                    @test check(ED_PS/N, PS, atol, rtol)
+                end
+                
+                @testset "Current Current Susceptibility" begin
+                    CCS = mean(dqmc.measurements[:CCS])
+                    ED_CCS = zeros(Float64, size(CCS))
+                    T = dqmc.stack.hopping_matrix
+                    for (dirs, src1, trg1, src2, trg2) in 
+                            MonteCarlo.EachLocalQuadBySyncedDistance{4}(dqmc, model)
+                        ED_CCS[dirs] -= expectation_value_integrated(
+                            # actually the order of this doesn't seem to matter
+                            current_density(src2, trg2, T), 
+                            current_density(src1, trg1, T),
+                            H, step = dqmc.parameters.delta_tau, beta = dqmc.parameters.beta, N_sites = N
+                        )
+                    end
+                    @test check(ED_CCS/N, CCS, atol, rtol)
                 end
             end
 
         end
     end
 end
+
+
+################################################################################
+### Checks with finite U ≠ 0 (Potentially large Trotter error)
+################################################################################
 
 
 @testset "Repulsive/Attractive Hubbard Model (ED)" begin


### PR DESCRIPTION
This mostly adds measurement checks against ED at `U = 0`. In that case all of them should be exact up to float precision errors. Testing them should help differentiate measurement implementation errors from numerical errors.