### PR TITLE
fix unequal time stack for irregular safe_mults and allow stuck simulations to fail

### DIFF
--- a/src/flavors/DQMC/DQMC.jl
+++ b/src/flavors/DQMC/DQMC.jl
@@ -154,7 +154,9 @@ See also: [`resume!`](@ref)
         safe_every::TimePeriod = Hour(10000),
         grace_period::TimePeriod = Minute(5),
         resumable_filename::String = "resumable_$(Dates.format(safe_before, "d_u_yyyy-HH_MM")).jld2",
-        overwrite = false
+        overwrite = false,
+        min_update_rate = 0.001,
+        fail_filename = "failed_$(Dates.format(safe_before, "d_u_yyyy-HH_MM")).jld2"
     )
 
     # Update number of sweeps
@@ -185,6 +187,8 @@ See also: [`resume!`](@ref)
     reverse_build_stack(mc, mc.stack)
     propagate(mc)
 
+    min_sweeps = round(Int, 1 / min_update_rate)
+
     _time = time() # for step estimations
     t0 = time() # for analysis.runtime, may need to reset
     verbose && println("\n\nThermalization stage - ", thermalization)
@@ -213,6 +217,17 @@ See also: [`resume!`](@ref)
                 for (requirement, group) in groups
                     apply!(requirement, group, mc, mc.model, mc.last_sweep)
                 end
+            end
+        end
+
+        if mc.last_sweep > min_sweeps
+            acc = max_acceptance(mc.scheduler)
+            if acc < min_update_rate
+                println("Cancelling Simulation due to low acceptance rate:")
+                println("\t", mc.last_sweep)
+                show_statistics(stdout, mc.scheduler, "\t\t")
+                save(fail_filename, mc, overwrite = overwrite, rename = false)
+                return true
             end
         end
 

--- a/src/flavors/DQMC/DQMC.jl
+++ b/src/flavors/DQMC/DQMC.jl
@@ -227,6 +227,9 @@ See also: [`resume!`](@ref)
                 println("\t", mc.last_sweep)
                 show_statistics(stdout, mc.scheduler, "\t\t")
                 save(fail_filename, mc, overwrite = overwrite, rename = false)
+                if overwrite && isfile(resumable_filename)
+                    rm(resumable_filename)
+                end
                 return true
             end
         end

--- a/src/flavors/DQMC/stack.jl
+++ b/src/flavors/DQMC/stack.jl
@@ -231,7 +231,7 @@ function taylor_exp(A; step_precision = 1, max_iter = 10_000)
     for n in 2:max_iter
         temp = temp * A ./ n
         output += temp
-        if all(temp ./ eps.(output) .< step_precision)
+        if all(abs.(temp) ./ eps.(abs.(output)) .< step_precision) # abs for Complex
             return output
         end
     end

--- a/src/flavors/DQMC/stack.jl
+++ b/src/flavors/DQMC/stack.jl
@@ -27,7 +27,7 @@ mutable struct DQMCStack{
     tmp1::GreensMatType
     tmp2::GreensMatType
 
-    ranges::Array{UnitRange, 1}
+    ranges::Vector{UnitRange{Int}}
     n_elements::Int
     # running internally over 0:mc.parameters.slices+1, where 0 and 
     # mc.parameters.slices+1 are artifcial to prepare next sweep direction.
@@ -49,7 +49,7 @@ mutable struct DQMCStack{
 
     # checkerboard hopping matrices
     checkerboard::Matrix{Int} # src, trg, bondid
-    groups::Vector{UnitRange}
+    groups::Vector{UnitRange{Int}}
     n_groups::Int
     chkr_hop_half::Vector{SparseMatrixCSC{HoppingElType, Int64}}
     chkr_hop_half_inv::Vector{SparseMatrixCSC{HoppingElType, Int64}}

--- a/src/flavors/DQMC/stack.jl
+++ b/src/flavors/DQMC/stack.jl
@@ -210,12 +210,34 @@ function init_hopping_matrix_exp(mc::DQMC, m::Model)
     end
 
     mc.stack.hopping_matrix = T
-    mc.stack.hopping_matrix_exp = exp(-0.5 * dtau * T)
-    mc.stack.hopping_matrix_exp_inv = exp(0.5 * dtau * T)
+    try
+        mc.stack.hopping_matrix_exp = exp(-0.5 * dtau * T)
+        mc.stack.hopping_matrix_exp_inv = exp(0.5 * dtau * T)
+    catch e
+        @error "LAPACK failed to calculate matrix exponentials... Using Taylor expansion" exception = e
+        mc.stack.hopping_matrix_exp = taylor_exp(-0.5 * dtau * T)
+        mc.stack.hopping_matrix_exp_inv = taylor_exp(0.5 * dtau * T)
+    end
     mc.stack.hopping_matrix_exp_squared = mc.stack.hopping_matrix_exp * mc.stack.hopping_matrix_exp
     mc.stack.hopping_matrix_exp_inv_squared = mc.stack.hopping_matrix_exp_inv * mc.stack.hopping_matrix_exp_inv
     nothing
 end
+
+function taylor_exp(A; step_precision = 1, max_iter = 10_000)
+    # if the next step adds less than step_precision (in unit of output float 
+    # epsilons) we stop
+    temp = A
+    output = I + A
+    for n in 2:max_iter
+        temp = temp * A ./ n
+        output += temp
+        if all(temp ./ eps.(output) .< step_precision)
+            return output
+        end
+    end
+    error("Failed to generate sufficiently accurate matrix exponential.")
+end
+
 
 # checkerboard
 rem_eff_zeros!(X::AbstractArray) = map!(e -> abs.(e)<1e-15 ? zero(e) : e,X,X)

--- a/src/flavors/DQMC/updates/scheduler.jl
+++ b/src/flavors/DQMC/updates/scheduler.jl
@@ -189,7 +189,7 @@ function max_acceptance(s::SimpleScheduler)
     output = 0.0
     for update in s.sequence
         if update isa AcceptanceStatistics
-            output = max(output, update.accepted / min(1, update.total))
+            output = max(output, update.accepted / max(1, update.total))
         end
     end
     output
@@ -388,12 +388,12 @@ function max_acceptance(s::AdaptiveScheduler)
     output = 0.0
     for update in s.sequence
         if update isa AcceptanceStatistics
-            output = max(output, update.accepted / min(1, update.total))
+            output = max(output, update.accepted / max(1, update.total))
         end
     end
     for update in s.adaptive_pool
         if update isa AcceptanceStatistics
-            output = max(output, update.accepted / min(1, update.total))
+            output = max(output, update.accepted / max(1, update.total))
         end
     end
     output

--- a/src/flavors/DQMC/updates/scheduler.jl
+++ b/src/flavors/DQMC/updates/scheduler.jl
@@ -185,6 +185,16 @@ function update(s::SimpleScheduler, mc::DQMC, model)
     return nothing
 end
 
+function max_acceptance(s::SimpleScheduler)
+    output = 0.0
+    for update in s.sequence
+        if update isa AcceptanceStatistics
+            output = max(output, update.accepted / min(1, update.total))
+        end
+    end
+    output
+end
+
 function show_statistics(io::IO, s::SimpleScheduler, prefix="")
     println(io, prefix, "Update statistics (since start):")
 
@@ -372,6 +382,21 @@ function update(s::AdaptiveScheduler, mc::DQMC, model)
     mc.last_sweep += 1
 
     return nothing
+end
+
+function max_acceptance(s::AdaptiveScheduler)
+    output = 0.0
+    for update in s.sequence
+        if update isa AcceptanceStatistics
+            output = max(output, update.accepted / min(1, update.total))
+        end
+    end
+    for update in s.adaptive_pool
+        if update isa AcceptanceStatistics
+            output = max(output, update.accepted / min(1, update.total))
+        end
+    end
+    output
 end
 
 function show_statistics(io::IO, s::AdaptiveScheduler, prefix="")

--- a/test/flavortests_DQMC.jl
+++ b/test/flavortests_DQMC.jl
@@ -1,5 +1,6 @@
 include("testfunctions.jl")
 
+
 @testset "DQMC Parameters" begin
     P1 = MonteCarlo.DQMCParameters(beta=5.0) #defaults to delta_tau = 0.1
     @test all((P1.beta, P1.delta_tau, P1.slices) .== (5.0, 0.1, 50))
@@ -15,6 +16,7 @@ include("testfunctions.jl")
 
     @test parameters(P4) == (beta = 5.0, delta_tau = 0.1, thermalization = 100, sweeps = 100)
 end
+
 
 @testset "Magnitude Stats" begin
     m = MonteCarlo.MagnitudeStats()
@@ -45,6 +47,7 @@ end
     @test mean(m) ≈ 10^(0.5*(log10(1e-7) + log10(1e-5)))
     @test length(m) == 2
 end
+
 
 @testset "DQMC utilities" begin
     m = HubbardModelAttractive(8, 1);
@@ -132,6 +135,7 @@ end
         typeof(dqmc.scheduler)
     }
 end
+
 
 
 @testset "GreensMatrix" begin
@@ -314,7 +318,22 @@ end
     
 end
 
+
 @testset "Unequal Time Stack" begin
+    @testset "range index search" begin
+        m = HubbardModelAttractive(2, 2)
+        mc = DQMC(m, beta = 2.3, safe_mult = 10, delta_tau = 0.1)
+        
+        @test MonteCarlo._find_range_with_value(mc, -81273) == 0
+        @test MonteCarlo._find_range_with_value(mc, 0) == 0
+        for i in 1:23
+            idx = MonteCarlo._find_range_with_value(mc, i)
+            @test i in mc.stack.ranges[idx]
+        end
+        @test MonteCarlo._find_range_with_value(mc, 24) == length(mc.stack.ranges)+1
+        @test MonteCarlo._find_range_with_value(mc, 1239874) == length(mc.stack.ranges)+1
+    end
+
     m = HubbardModelAttractive(6, 1);
     dqmc = DQMC(m; beta=15.0, safe_mult=5)
     MonteCarlo.initialize_stack(dqmc, dqmc.ut_stack)

--- a/test/flavortests_DQMC.jl
+++ b/test/flavortests_DQMC.jl
@@ -237,6 +237,20 @@ end
     # constructors
     dqmc = DQMC(m; beta=5.0)
 
+    # subtype getters
+    @test MonteCarlo.geltype(dqmc.stack) == Float64
+    @test MonteCarlo.heltype(dqmc.stack) == Float64
+    @test MonteCarlo.gmattype(dqmc.stack) == Matrix{Float64}
+    @test MonteCarlo.hmattype(dqmc.stack) == Matrix{Float64}
+    @test MonteCarlo.imattype(dqmc.stack) == Diagonal{Float64, Vector{Float64}}
+    
+    @test MonteCarlo.geltype(dqmc) == Float64
+    @test MonteCarlo.heltype(dqmc) == Float64
+    @test MonteCarlo.gmattype(dqmc) == Matrix{Float64}
+    @test MonteCarlo.hmattype(dqmc) == Matrix{Float64}
+    @test MonteCarlo.imattype(dqmc) == Diagonal{Float64, Vector{Float64}}
+
+
     # generic checkerboard
     sq = MonteCarlo.SquareLattice(4);
     @test MonteCarlo.build_checkerboard(sq) == ([1.0 3.0 5.0 7.0 9.0 11.0 13.0 15.0 1.0 2.0 4.0 6.0 9.0 10.0 12.0 14.0 2.0 3.0 4.0 5.0 8.0 10.0 11.0 16.0 6.0 7.0 8.0 12.0 13.0 14.0 15.0 16.0; 2.0 4.0 6.0 8.0 10.0 12.0 14.0 16.0 5.0 3.0 8.0 7.0 13.0 11.0 16.0 15.0 6.0 7.0 1.0 9.0 12.0 14.0 15.0 13.0 10.0 11.0 5.0 9.0 1.0 2.0 3.0 4.0; 1.0 5.0 9.0 13.0 17.0 21.0 25.0 29.0 2.0 3.0 8.0 11.0 18.0 19.0 24.0 27.0 4.0 6.0 7.0 10.0 16.0 20.0 22.0 31.0 12.0 14.0 15.0 23.0 26.0 28.0 30.0 32.0], UnitRange[1:8, 9:16, 17:24, 25:32], 4)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -2,6 +2,11 @@ let
 
     # Complex and Real Matrix mults, BlockDiagonal, UDT
     for type in (Float64, ComplexF64)
+        M = rand(type, 8, 8)
+        E = exp(M)
+        T = MonteCarlo.taylor_exp(M)
+        @test all(abs.(T .- E) .< 10_000eps.(abs.(E)))
+
         @testset "avx multiplications ($type)" begin
             A = rand(type, 8, 8)
             B = rand(type, 8, 8)
@@ -142,6 +147,11 @@ let
             B3 = BlockDiagonal(rand(type, 4, 4), rand(type, 4, 4))
             M3 = Matrix(B3)
         
+            # taylor exp
+            E = exp(Matrix(B))
+            T = MonteCarlo.taylor_exp(B)
+            @test all(abs.(T .- E) .< 10_000eps.(E))
+
             # Test (avx) multiplications
             vmul!(B1, B2, B3)
             vmul!(M1, M2, M3)
@@ -226,6 +236,11 @@ let
         C2 = StructArray(M2)
         M3 = rand(ComplexF64, 8, 8)    
         C3 = StructArray(M3)
+
+        # taylor exp
+        E = exp(Matrix(M1))
+        T = MonteCarlo.taylor_exp(C1)
+        @test all(abs.(T .- E) .< 10_000eps.(E))
 
         @test C1 isa CMat64
         @test M1 == C1

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -150,7 +150,7 @@ let
             # taylor exp
             E = exp(Matrix(B))
             T = MonteCarlo.taylor_exp(B)
-            @test all(abs.(T .- E) .< 10_000eps.(E))
+            @test all(abs.(T .- E) .< 10_000eps.(abs.(E)))
 
             # Test (avx) multiplications
             vmul!(B1, B2, B3)
@@ -240,7 +240,7 @@ let
         # taylor exp
         E = exp(Matrix(M1))
         T = MonteCarlo.taylor_exp(C1)
-        @test all(abs.(T .- E) .< 10_000eps.(E))
+        @test all(abs.(T .- E) .< 10_000eps.(abs.(E)))
 
         @test C1 isa CMat64
         @test M1 == C1

--- a/test/updates.jl
+++ b/test/updates.jl
@@ -90,6 +90,7 @@ MonteCarlo.update(::GoodUpdate, args...) = 1.0
         io = IOBuffer()
         MonteCarlo.show_statistics(io, mc.scheduler)
         @test String(take!(io)) == "Update statistics (since start):\n\tBadUpdate              0.0% accepted   (  0 / 100)\n\tGoodUpdate           100.0% accepted   (200 / 200)\n\t--------------------------------------------------\n\tTotal                 66.7% accepted   (200 / 300)\n"
+        @test MonteCarlo.max_acceptance(scheduler) == 1.0
     end
 end
 


### PR DESCRIPTION
I've had some simulation that do not accept any updates. In these cases it really doesn't make sense to have them continue, so this pr allows them to fail.

I also forgot to update the unequal time stack to match the irregular safe_mult blocks from #145, so I'm adding it here