### PR TITLE
Hermitian optimizations

### DIFF
--- a/src/MonteCarlo.jl
+++ b/src/MonteCarlo.jl
@@ -1,6 +1,6 @@
 module MonteCarlo
 
-using LinearAlgebra: AbstractMatrix
+using LinearAlgebra: AbstractMatrix, Hermitian
 using Reexport
 # Loading the RNG will fail if Random is nto exported
 @reexport using Random, BinningAnalysis

--- a/src/flavors/DQMC/linalg/blockdiagonal.jl
+++ b/src/flavors/DQMC/linalg/blockdiagonal.jl
@@ -220,31 +220,31 @@ end
 function vmul!(C::BD{N}, A::Adjoint, B::Diagonal) where {N}
     n = size(C.blocks[1], 1)
     @inbounds for i in 1:N
-        vmul!(C.blocks[i], Adjoint(A.parent.blocks[i]), B, (i-1)*n+1 : i*n)
+        vmul!(C.blocks[i], adjoint(A.parent.blocks[i]), B, (i-1)*n+1 : i*n)
     end
     nothing
 end
 function vmul!(C::BD{N}, A::Diagonal, B::Adjoint) where {N}
     n = size(C.blocks[1], 1)
     @inbounds for i in 1:N
-        vmul!(C.blocks[i], A, Adjoint(B.parent.blocks[i]), (i-1)*n+1 : i*n)
+        vmul!(C.blocks[i], A, adjoint(B.parent.blocks[i]), (i-1)*n+1 : i*n)
     end
     nothing
 end
 
 function vmul!(C::BD{N}, A::BD{N}, B::Adjoint) where {N}
     @inbounds for i in 1:N
-        vmul!(C.blocks[i], A.blocks[i], Adjoint(B.parent.blocks[i]))
+        vmul!(C.blocks[i], A.blocks[i], adjoint(B.parent.blocks[i]))
     end
 end
 function vmul!(C::BD{N}, A::Adjoint, B::BD{N}) where {N}
     @inbounds for i in 1:N
-        vmul!(C.blocks[i], Adjoint(A.parent.blocks[i]), B.blocks[i])
+        vmul!(C.blocks[i], adjoint(A.parent.blocks[i]), B.blocks[i])
     end
 end
 function vmul!(C::BD{N}, A::Adjoint, B::Adjoint) where {N}
     @inbounds for i in 1:N
-        vmul!(C.blocks[i], Adjoint(A.parent.blocks[i]), Adjoint(B.parent.blocks[i]))
+        vmul!(C.blocks[i], adjoint(A.parent.blocks[i]), adjoint(B.parent.blocks[i]))
     end
 end
 function rvmul!(A::BD{N}, B::Diagonal) where {N}

--- a/src/flavors/DQMC/linalg/blockdiagonal.jl
+++ b/src/flavors/DQMC/linalg/blockdiagonal.jl
@@ -201,6 +201,7 @@ function vmul!(C::BD{N}, A::BD{N}, B::BD{N}) where {N}
     end
     nothing
 end
+
 function vmul!(C::BD{N}, A::BD{N}, B::Diagonal) where {N}
     n = size(C.blocks[1], 1)
     @inbounds for i in 1:N
@@ -216,6 +217,21 @@ function vmul!(C::BD{N}, A::Diagonal, B::BD{N}) where {N}
     end
     nothing
 end
+function vmul!(C::BD{N}, A::Adjoint, B::Diagonal) where {N}
+    n = size(C.blocks[1], 1)
+    @inbounds for i in 1:N
+        vmul!(C.blocks[i], Adjoint(A.parent.blocks[i]), B, (i-1)*n+1 : i*n)
+    end
+    nothing
+end
+function vmul!(C::BD{N}, A::Diagonal, B::Adjoint) where {N}
+    n = size(C.blocks[1], 1)
+    @inbounds for i in 1:N
+        vmul!(C.blocks[i], A, Adjoint(B.parent.blocks[i]), (i-1)*n+1 : i*n)
+    end
+    nothing
+end
+
 function vmul!(C::BD{N}, A::BD{N}, B::Adjoint) where {N}
     @inbounds for i in 1:N
         vmul!(C.blocks[i], A.blocks[i], Adjoint(B.parent.blocks[i]))

--- a/src/flavors/DQMC/linalg/complex.jl
+++ b/src/flavors/DQMC/linalg/complex.jl
@@ -660,6 +660,7 @@ end
 ### GHQ
 ################################################################################
 
+
 @inline function vmul!(C::CMat64, A::Matrix{<: Float64}, D::Diagonal{ComplexF64, <: CVec64})
     vmul!(C.re, A, Diagonal(D.diag.re))
     vmul!(C.im, A, Diagonal(D.diag.im))
@@ -693,46 +694,46 @@ end
 
 
 @inline function vmul!(C::CMat64, A::Adjoint{ComplexF64, <: CMat64}, B::Diagonal{<: Real})
-    vmul!(C.re, Adjoint(A.parent.re), B)
-    vmul!(C.im, Adjoint(A.parent.im), B, -1.0)
+    vmul!(C.re, adjoint(A.parent.re), B)
+    vmul!(C.im, adjoint(A.parent.im), B, -1.0)
 end
 @inline function vmul!(C::CMat64, A::Adjoint{ComplexF64, <: CMat64}, B::Diagonal{<: Real}, range)
-    @views vmul!(C.re, Adjoint(A.parent.re), Diagonal(B.diag[range]))
-    @views vmul!(C.im, Adjoint(A.parent.im), Diagonal(B.diag[range]), -1.0)
+    @views vmul!(C.re, adjoint(A.parent.re), Diagonal(B.diag[range]))
+    @views vmul!(C.im, adjoint(A.parent.im), Diagonal(B.diag[range]), -1.0)
 end
 
 @inline function vmul!(C::CMat64, A::Adjoint{ComplexF64, <: CMat64}, D::Diagonal{ComplexF64, <: CVec64})
-    vmul!(   C.re, Adjoint(A.parent.re), Diagonal(D.diag.re))
-    vmuladd!(C.re, Adjoint(A.parent.im), Diagonal(D.diag.im))
-    vmul!(   C.im, Adjoint(A.parent.re), Diagonal(D.diag.im))
-    vmuladd!(C.im, Adjoint(A.parent.im), Diagonal(D.diag.re), -1.0)
+    vmul!(   C.re, adjoint(A.parent.re), Diagonal(D.diag.re))
+    vmuladd!(C.re, adjoint(A.parent.im), Diagonal(D.diag.im))
+    vmul!(   C.im, adjoint(A.parent.re), Diagonal(D.diag.im))
+    vmuladd!(C.im, adjoint(A.parent.im), Diagonal(D.diag.re), -1.0)
 end
 @inline function vmul!(C::CMat64, A::Adjoint{ComplexF64, <: CMat64}, D::Diagonal{ComplexF64, <: CVec64}, range)
-    @views vmul!(   C.re, Adjoint(A.parent.re), Diagonal(D.diag.re[range]))
-    @views vmuladd!(C.re, Adjoint(A.parent.im), Diagonal(D.diag.im[range]))
-    @views vmul!(   C.im, Adjoint(A.parent.re), Diagonal(D.diag.im[range]))
-    @views vmuladd!(C.im, Adjoint(A.parent.im), Diagonal(D.diag.re[range]), -1.0)
+    @views vmul!(   C.re, adjoint(A.parent.re), Diagonal(D.diag.re[range]))
+    @views vmuladd!(C.re, adjoint(A.parent.im), Diagonal(D.diag.im[range]))
+    @views vmul!(   C.im, adjoint(A.parent.re), Diagonal(D.diag.im[range]))
+    @views vmuladd!(C.im, adjoint(A.parent.im), Diagonal(D.diag.re[range]), -1.0)
 end
 
 @inline function vmul!(C::CMat64, A::Diagonal{<: Real}, B::Adjoint{ComplexF64, <: CMat64})
-    vmul!(C.re, A, Adjoint(B.parent.re))
-    vmul!(C.im, A, Adjoint(B.parent.im), -1.0)
+    vmul!(C.re, A, adjoint(B.parent.re))
+    vmul!(C.im, A, adjoint(B.parent.im), -1.0)
 end
 @inline function vmul!(C::CMat64, A::Diagonal{<: Real}, B::Adjoint{ComplexF64, <: CMat64}, range)
-    @views vmul!(C.re, A, Adjoint(B.parent.re), range)
-    @views vmul!(C.im, A, Adjoint(B.parent.im), range, -1.0)
+    @views vmul!(C.re, A, adjoint(B.parent.re), range)
+    @views vmul!(C.im, A, adjoint(B.parent.im), range, -1.0)
 end
 @inline function vmul!(C::CMat64, A::Diagonal{ComplexF64, <: CVec64}, B::Adjoint{ComplexF64, <: CMat64})
-    vmul!(   C.re, Diagonal(A.diag.re), Adjoint(B.parent.re))
-    vmuladd!(C.re, Diagonal(A.diag.im), Adjoint(B.parent.im))
-    vmul!(   C.im, Diagonal(A.diag.im), Adjoint(B.parent.re))
-    vmuladd!(C.im, Diagonal(A.diag.re), Adjoint(B.parent.im), -1.0)
+    vmul!(   C.re, Diagonal(A.diag.re), adjoint(B.parent.re))
+    vmuladd!(C.re, Diagonal(A.diag.im), adjoint(B.parent.im))
+    vmul!(   C.im, Diagonal(A.diag.im), adjoint(B.parent.re))
+    vmuladd!(C.im, Diagonal(A.diag.re), adjoint(B.parent.im), -1.0)
 end
 @inline function vmul!(C::CMat64, A::Diagonal{ComplexF64, <: CVec64}, B::Adjoint{ComplexF64, <: CMat64}, range)
-    @views vmul!(   C.re, Diagonal(A.diag.re[range]), Adjoint(B.parent.re))
-    @views vmuladd!(C.re, Diagonal(A.diag.im[range]), Adjoint(B.parent.im))
-    @views vmul!(   C.im, Diagonal(A.diag.im[range]), Adjoint(B.parent.re))
-    @views vmuladd!(C.im, Diagonal(A.diag.re[range]), Adjoint(B.parent.im), -1.0)
+    @views vmul!(   C.re, Diagonal(A.diag.re[range]), adjoint(B.parent.re))
+    @views vmuladd!(C.re, Diagonal(A.diag.im[range]), adjoint(B.parent.im))
+    @views vmul!(   C.im, Diagonal(A.diag.im[range]), adjoint(B.parent.re))
+    @views vmuladd!(C.im, Diagonal(A.diag.re[range]), adjoint(B.parent.im), -1.0)
 end
 
 @inline function vmul!(C::CMat64, A::Adjoint{Float64}, B::Diagonal{<: Real})

--- a/src/flavors/DQMC/linalg/complex.jl
+++ b/src/flavors/DQMC/linalg/complex.jl
@@ -188,12 +188,12 @@ end
     vmul!(   C.im, Diagonal(A.diag.re), B.im)
     vmuladd!(C.im, Diagonal(A.diag.im), B.re)
 end
-@inline function vmul!(C::CMat64, A::Diagonal{ComplexF64, <: CVec64}, B::CMat64, range)
-    @views vmul!(   C.re, Diagonal(A.diag.re[range]), B.re)
-    @views vmuladd!(C.re, Diagonal(A.diag.im[range]), B.im, -1.0)
-    @views vmul!(   C.im, Diagonal(A.diag.re[range]), B.im)
-    @views vmuladd!(C.im, Diagonal(A.diag.im[range]), B.re)
-end
+# @inline function vmul!(C::CMat64, A::Diagonal{ComplexF64, <: CVec64}, B::CMat64, range)
+#     @views vmul!(   C.re, Diagonal(A.diag.re[range]), B.re)
+#     @views vmuladd!(C.re, Diagonal(A.diag.im[range]), B.im, -1.0)
+#     @views vmul!(   C.im, Diagonal(A.diag.re[range]), B.im)
+#     @views vmuladd!(C.im, Diagonal(A.diag.im[range]), B.re)
+# end
 
 # tested
 @inline function vmul!(C::CMat64, A::CMat64, X::Adjoint{ComplexF64, <: CMat64})
@@ -665,18 +665,18 @@ end
     vmul!(C.re, A, Diagonal(D.diag.re))
     vmul!(C.im, A, Diagonal(D.diag.im))
 end
-@inline function vmul!(C::CMat64, A::Matrix{<: Float64}, D::Diagonal{ComplexF64, <: CVec64}, range)
-    @views vmul!(C.re, A, Diagonal(D.diag.re[range]))
-    @views vmul!(C.im, A, Diagonal(D.diag.im[range]))
-end
+# @inline function vmul!(C::CMat64, A::Matrix{<: Float64}, D::Diagonal{ComplexF64, <: CVec64}, range)
+#     @views vmul!(C.re, A, Diagonal(D.diag.re[range]))
+#     @views vmul!(C.im, A, Diagonal(D.diag.im[range]))
+# end
 @inline function vmul!(C::CMat64, D::Diagonal{ComplexF64, <: CVec64}, B::Matrix{<: Float64})
     vmul!(C.re, Diagonal(D.diag.re), B)
     vmul!(C.im, Diagonal(D.diag.im), B)
 end
-@inline function vmul!(C::CMat64, D::Diagonal{ComplexF64, <: CVec64}, B::Matrix{<: Float64}, range)
-    @views vmul!(C.re, Diagonal(D.diag.re[range]), B)
-    @views vmul!(C.im, Diagonal(D.diag.im[range]), B)
-end
+# @inline function vmul!(C::CMat64, D::Diagonal{ComplexF64, <: CVec64}, B::Matrix{<: Float64}, range)
+#     @views vmul!(C.re, Diagonal(D.diag.re[range]), B)
+#     @views vmul!(C.im, Diagonal(D.diag.im[range]), B)
+# end
 
 @inline function vmul!(C::CMat64, A::CMat64, B::Matrix{Float64})
     vmul!(C.re, A.re, B)
@@ -697,10 +697,10 @@ end
     vmul!(C.re, adjoint(A.parent.re), B)
     vmul!(C.im, adjoint(A.parent.im), B, -1.0)
 end
-@inline function vmul!(C::CMat64, A::Adjoint{ComplexF64, <: CMat64}, B::Diagonal{<: Real}, range)
-    @views vmul!(C.re, adjoint(A.parent.re), Diagonal(B.diag[range]))
-    @views vmul!(C.im, adjoint(A.parent.im), Diagonal(B.diag[range]), -1.0)
-end
+# @inline function vmul!(C::CMat64, A::Adjoint{ComplexF64, <: CMat64}, B::Diagonal{<: Real}, range)
+#     @views vmul!(C.re, adjoint(A.parent.re), Diagonal(B.diag[range]))
+#     @views vmul!(C.im, adjoint(A.parent.im), Diagonal(B.diag[range]), -1.0)
+# end
 
 @inline function vmul!(C::CMat64, A::Adjoint{ComplexF64, <: CMat64}, D::Diagonal{ComplexF64, <: CVec64})
     vmul!(   C.re, adjoint(A.parent.re), Diagonal(D.diag.re))
@@ -708,42 +708,42 @@ end
     vmul!(   C.im, adjoint(A.parent.re), Diagonal(D.diag.im))
     vmuladd!(C.im, adjoint(A.parent.im), Diagonal(D.diag.re), -1.0)
 end
-@inline function vmul!(C::CMat64, A::Adjoint{ComplexF64, <: CMat64}, D::Diagonal{ComplexF64, <: CVec64}, range)
-    @views vmul!(   C.re, adjoint(A.parent.re), Diagonal(D.diag.re[range]))
-    @views vmuladd!(C.re, adjoint(A.parent.im), Diagonal(D.diag.im[range]))
-    @views vmul!(   C.im, adjoint(A.parent.re), Diagonal(D.diag.im[range]))
-    @views vmuladd!(C.im, adjoint(A.parent.im), Diagonal(D.diag.re[range]), -1.0)
-end
+# @inline function vmul!(C::CMat64, A::Adjoint{ComplexF64, <: CMat64}, D::Diagonal{ComplexF64, <: CVec64}, range)
+#     @views vmul!(   C.re, adjoint(A.parent.re), Diagonal(D.diag.re[range]))
+#     @views vmuladd!(C.re, adjoint(A.parent.im), Diagonal(D.diag.im[range]))
+#     @views vmul!(   C.im, adjoint(A.parent.re), Diagonal(D.diag.im[range]))
+#     @views vmuladd!(C.im, adjoint(A.parent.im), Diagonal(D.diag.re[range]), -1.0)
+# end
 
 @inline function vmul!(C::CMat64, A::Diagonal{<: Real}, B::Adjoint{ComplexF64, <: CMat64})
     vmul!(C.re, A, adjoint(B.parent.re))
     vmul!(C.im, A, adjoint(B.parent.im), -1.0)
 end
-@inline function vmul!(C::CMat64, A::Diagonal{<: Real}, B::Adjoint{ComplexF64, <: CMat64}, range)
-    @views vmul!(C.re, A, adjoint(B.parent.re), range)
-    @views vmul!(C.im, A, adjoint(B.parent.im), range, -1.0)
-end
+# @inline function vmul!(C::CMat64, A::Diagonal{<: Real}, B::Adjoint{ComplexF64, <: CMat64}, range)
+#     @views vmul!(C.re, A, adjoint(B.parent.re), range)
+#     @views vmul!(C.im, A, adjoint(B.parent.im), range, -1.0)
+# end
 @inline function vmul!(C::CMat64, A::Diagonal{ComplexF64, <: CVec64}, B::Adjoint{ComplexF64, <: CMat64})
     vmul!(   C.re, Diagonal(A.diag.re), adjoint(B.parent.re))
     vmuladd!(C.re, Diagonal(A.diag.im), adjoint(B.parent.im))
     vmul!(   C.im, Diagonal(A.diag.im), adjoint(B.parent.re))
     vmuladd!(C.im, Diagonal(A.diag.re), adjoint(B.parent.im), -1.0)
 end
-@inline function vmul!(C::CMat64, A::Diagonal{ComplexF64, <: CVec64}, B::Adjoint{ComplexF64, <: CMat64}, range)
-    @views vmul!(   C.re, Diagonal(A.diag.re[range]), adjoint(B.parent.re))
-    @views vmuladd!(C.re, Diagonal(A.diag.im[range]), adjoint(B.parent.im))
-    @views vmul!(   C.im, Diagonal(A.diag.im[range]), adjoint(B.parent.re))
-    @views vmuladd!(C.im, Diagonal(A.diag.re[range]), adjoint(B.parent.im), -1.0)
-end
+# @inline function vmul!(C::CMat64, A::Diagonal{ComplexF64, <: CVec64}, B::Adjoint{ComplexF64, <: CMat64}, range)
+#     @views vmul!(   C.re, Diagonal(A.diag.re[range]), adjoint(B.parent.re))
+#     @views vmuladd!(C.re, Diagonal(A.diag.im[range]), adjoint(B.parent.im))
+#     @views vmul!(   C.im, Diagonal(A.diag.im[range]), adjoint(B.parent.re))
+#     @views vmuladd!(C.im, Diagonal(A.diag.re[range]), adjoint(B.parent.im), -1.0)
+# end
 
 @inline function vmul!(C::CMat64, A::Adjoint{Float64}, B::Diagonal{<: Real})
     vmul!(C.re, A, B)
     copyto!(C.im, 0)
 end
-@inline function vmul!(C::CMat64, A::Adjoint{Float64}, B::Diagonal{<: Real}, range)
-    @views vmul!(C.re, A, Diagonal(B.diag[range]))
-    @views copyto!(C.im, 0)
-end
+# @inline function vmul!(C::CMat64, A::Adjoint{Float64}, B::Diagonal{<: Real}, range)
+#     @views vmul!(C.re, A, Diagonal(B.diag[range]))
+#     @views copyto!(C.im, 0)
+# end
 
 @inline function vmul!(C::CMat64, A::Adjoint{Float64}, D::Diagonal{ComplexF64, <: CVec64})
     vmul!(C.re, A, Diagonal(D.diag.re))
@@ -758,10 +758,10 @@ end
     vmul!(C.re, A, B)
     copyto!(C.im, 0)
 end
-@inline function vmul!(C::CMat64, A::Diagonal{<: Real}, B::Adjoint{Float64}, range)
-    @views vmul!(C.re, A, B, range)
-    copyto!(C.im, 0)
-end
+# @inline function vmul!(C::CMat64, A::Diagonal{<: Real}, B::Adjoint{Float64}, range)
+#     @views vmul!(C.re, A, B, range)
+#     copyto!(C.im, 0)
+# end
 @inline function vmul!(C::CMat64, A::Diagonal{ComplexF64, <: CVec64}, B::Adjoint{Float64})
     vmul!(C.re, Diagonal(A.diag.re), B)
     vmul!(C.im, Diagonal(A.diag.im), B)

--- a/src/flavors/DQMC/linalg/fallbacks.jl
+++ b/src/flavors/DQMC/linalg/fallbacks.jl
@@ -66,9 +66,3 @@ end
 # Hermitian optimization
 vmul!(C::AbstractArray, A::AbstractArray, B::Hermitian) = vmul!(C, A, adjoint(B.data)) # slightly faster
 vmul!(C::AbstractArray, A::Hermitian, B::AbstractArray) = vmul!(C, adjoint(A.data), B) # lots faster
-function vmul!(C::AbstractArray, A::AbstractArray, B::Adjoint{<: Any, <: Hermitian})
-    vmul!(C, A, adjoint(B.parent.data))
-end
-function vmul!(C::AbstractArray, A::Adjoint{<: Any, <: Hermitian}, B::AbstractArray)
-    vmul!(C, adjoint(A.parent.data), B)
-end

--- a/src/flavors/DQMC/linalg/fallbacks.jl
+++ b/src/flavors/DQMC/linalg/fallbacks.jl
@@ -62,3 +62,13 @@ function rdivp!(A::Matrix{<: Complex}, T::Matrix{<: Complex}, O::Matrix{<: Compl
     end
     A
 end
+
+# Hermitian optimization
+vmul!(C::AbstractArray, A::AbstractArray, B::Hermitian) = vmul!(C, A, adjoint(B.data)) # slightly faster
+vmul!(C::AbstractArray, A::Hermitian, B::AbstractArray) = vmul!(C, adjoint(A.data), B) # lots faster
+function vmul!(C::AbstractArray, A::AbstractArray, B::Adjoint{<: Any, <: Hermitian})
+    vmul!(C, A, adjoint(B.parent.data))
+end
+function vmul!(C::AbstractArray, A::Adjoint{<: Any, <: Hermitian}, B::AbstractArray)
+    vmul!(C, adjoint(A.parent.data), B)
+end

--- a/src/flavors/DQMC/linalg/real.jl
+++ b/src/flavors/DQMC/linalg/real.jl
@@ -57,6 +57,11 @@ function vmul!(C::Matrix{T}, A::Diagonal{T}, B::Adjoint) where {T <: Real}
         C[m,n] = A.diag[m] * B.parent[n,m]
     end
 end
+function vmul!(C::Matrix{T}, A::Diagonal{T}, B::Adjoint, factor::Real) where {T <: Real}
+    @turbo for m in 1:size(C, 1), n in 1:size(C, 2)
+        C[m,n] = factor * A.diag[m] * B.parent[n,m]
+    end
+end
 function vmul!(C::Matrix{T}, A::Diagonal{T}, B::Adjoint, range) where {T <: Real}
     @views d = A.diag[range]
     @turbo for m in 1:size(C, 1), n in 1:size(C, 2)

--- a/src/flavors/DQMC/linalg/real.jl
+++ b/src/flavors/DQMC/linalg/real.jl
@@ -41,6 +41,11 @@ function vmul!(C::Matrix{T}, A::Adjoint, B::Diagonal{T}) where {T <: Real}
         C[m,n] = A.parent[n,m] * B.diag[n]
     end
 end
+function vmul!(C::Matrix{T}, A::Adjoint, B::Diagonal{T}, factor::Real) where {T <: Real}
+    @turbo for m in 1:size(A, 1), n in 1:size(A, 2)
+        C[m,n] = factor * A.parent[n,m] * B.diag[n]
+    end
+end
 function vmul!(C::Matrix{T}, A::Adjoint, B::Diagonal{T}, range) where {T <: Real}
     @views d = B.diag[range]
     @turbo for m in 1:size(A, 1), n in 1:size(A, 2)

--- a/src/flavors/DQMC/linalg/real.jl
+++ b/src/flavors/DQMC/linalg/real.jl
@@ -35,6 +35,30 @@ function vmul!(C::Matrix{T}, A::Diagonal{T}, B::Matrix{T}, range) where {T <: Re
         C[m,n] = d[m] * B[m,n]
     end
 end
+
+function vmul!(C::Matrix{T}, A::Adjoint, B::Diagonal{T}) where {T <: Real}
+    @turbo for m in 1:size(A, 1), n in 1:size(A, 2)
+        C[m,n] = A.parent[n,m] * B.diag[n]
+    end
+end
+function vmul!(C::Matrix{T}, A::Adjoint, B::Diagonal{T}, range) where {T <: Real}
+    @views d = B.diag[range]
+    @turbo for m in 1:size(A, 1), n in 1:size(A, 2)
+        C[m,n] = A.parent[n,m] * d[n]
+    end
+end
+function vmul!(C::Matrix{T}, A::Diagonal{T}, B::Adjoint) where {T <: Real}
+    @turbo for m in 1:size(C, 1), n in 1:size(C, 2)
+        C[m,n] = A.diag[m] * B.parent[n,m]
+    end
+end
+function vmul!(C::Matrix{T}, A::Diagonal{T}, B::Adjoint, range) where {T <: Real}
+    @views d = A.diag[range]
+    @turbo for m in 1:size(C, 1), n in 1:size(C, 2)
+        C[m,n] = d[m] * B.parent[n,m]
+    end
+end
+
 function vmul!(C::Matrix{T}, A::Matrix{T}, X::Adjoint{T}) where {T <: Real}
     B = X.parent
     @turbo for m in 1:size(A, 1), n in 1:size(B, 2)

--- a/src/flavors/DQMC/stack.jl
+++ b/src/flavors/DQMC/stack.jl
@@ -113,7 +113,7 @@ function DQMCStack(field::AbstractField, model::Model)
     GET = greens_eltype(field, model)
     
     IMT = interaction_matrix_type(field, model)
-    HMT = hopping_matrix_type(field, model)
+    HMT = Hermitian{HET, hopping_matrix_type(field, model)}
     GMT = greens_matrix_type(field, model)
 
     DQMCStack{GET, HET, GMT, HMT, IMT}(FieldCache(field, model))
@@ -223,10 +223,10 @@ function init_hopping_matrix_exp(mc::DQMC, m::Model)
     end
 
     mc.stack.hopping_matrix = T
-    mc.stack.hopping_matrix_exp = fallback_exp(-0.5 * dtau * T)
-    mc.stack.hopping_matrix_exp_inv = fallback_exp(0.5 * dtau * T)
-    mc.stack.hopping_matrix_exp_squared = mc.stack.hopping_matrix_exp * mc.stack.hopping_matrix_exp
-    mc.stack.hopping_matrix_exp_inv_squared = mc.stack.hopping_matrix_exp_inv * mc.stack.hopping_matrix_exp_inv
+    mc.stack.hopping_matrix_exp = Hermitian(fallback_exp(-0.5 * dtau * T))
+    mc.stack.hopping_matrix_exp_inv = Hermitian(fallback_exp(0.5 * dtau * T))
+    mc.stack.hopping_matrix_exp_squared = Hermitian(fallback_exp(dtau * T))
+    mc.stack.hopping_matrix_exp_inv_squared = Hermitian(fallback_exp(dtau * T))
     nothing
 end
 

--- a/test/flavortests_DQMC.jl
+++ b/test/flavortests_DQMC.jl
@@ -270,13 +270,13 @@ end
     @test MonteCarlo.geltype(dqmc.stack) == Float64
     @test MonteCarlo.heltype(dqmc.stack) == Float64
     @test MonteCarlo.gmattype(dqmc.stack) == Matrix{Float64}
-    @test MonteCarlo.hmattype(dqmc.stack) == Matrix{Float64}
+    @test MonteCarlo.hmattype(dqmc.stack) == Hermitian{Float64, Matrix{Float64}}
     @test MonteCarlo.imattype(dqmc.stack) == Diagonal{Float64, Vector{Float64}}
     
     @test MonteCarlo.geltype(dqmc) == Float64
     @test MonteCarlo.heltype(dqmc) == Float64
     @test MonteCarlo.gmattype(dqmc) == Matrix{Float64}
-    @test MonteCarlo.hmattype(dqmc) == Matrix{Float64}
+    @test MonteCarlo.hmattype(dqmc) == Hermitian{Float64, Matrix{Float64}}
     @test MonteCarlo.imattype(dqmc) == Diagonal{Float64, Vector{Float64}}
 
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -263,6 +263,7 @@ let
         M3 = rand(ComplexF64, N, N)    
         C3 = StructArray(M3)
 
+        R = rand(Float64, N, N)
         MH = Hermitian(M3 + M3')
         CH = Hermitian(StructArray(M3 + M3'))
 
@@ -297,9 +298,21 @@ let
         # Diagonal
         @test check_vmul!(C1, C2, D, M2, D, atol)
         @test check_vmul!(C1, C2', D, M2', D, atol)
+        @test check_vmul!(C1, D, C2, D, M2, atol)
+        @test check_vmul!(C1, D, C2', D, M2', atol)
+        @test check_vmul!(C1, D, R, D, R, atol)
+        @test check_vmul!(C1, D, R', D, R', atol)
 
         @test check_vmul!(C1, C2, DCSA, M2, DC, atol)
         @test check_vmul!(C1, C2', DCSA, M2', DC, atol)
+        @test check_vmul!(C1, DCSA, C2, DC, M2, atol)
+        @test check_vmul!(C1, DCSA, C2', DC, M2', atol)
+
+        # GHQ
+        @test check_vmul!(C1, R, DCSA, R, DC, atol)
+        @test check_vmul!(C1, DCSA, R, DC, R, atol)
+        @test check_vmul!(C1, C2, R, M2, R, atol)
+        @test check_vmul!(C1, R, C2, R, M2, atol)
 
         copyto!(M1, C1)
         rvmul!(C1, D)
@@ -376,7 +389,6 @@ let
         @test Matrix(C1) * Diagonal(D) * Matrix(C2) ≈ M2
 
         # real adjoint + complex for Hermitian
-        R = rand(Float64, N, N)
         copyto!(M2, C2) # just in case
         vmul!(C1, C2, R')
         @test C1 ≈ M2 * R' atol = atol

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -1,34 +1,45 @@
 let
+    N = 6
+
+    function check_vmul!(C, A, B, atol)
+        vmul!(C, A, B)
+        @test A * B ≈ C atol = atol
+    end
 
     # Complex and Real Matrix mults, BlockDiagonal, UDT
     for type in (Float64, ComplexF64)
-        M = rand(type, 8, 8)
+        M = rand(type, N, N)
         E = exp(M)
         T = MonteCarlo.taylor_exp(M)
         @test all(abs.(T .- E) .< 10_000eps.(abs.(E)))
 
         @testset "avx multiplications ($type)" begin
-            A = rand(type, 8, 8)
-            B = rand(type, 8, 8)
-            C = rand(type, 8, 8)
+            A = rand(type, N, N)
+            B = rand(type, N, N)
+            C = rand(type, N, N)
+            H = Hermitian(B + B')
+            D = Diagonal(rand(N))
             atol = 100eps(Float64)
             type == ComplexF64 && (atol *= sqrt(2))
 
-            vmul!(C, A, B)
-            @test A * B ≈ C atol = atol
+            # Adjoints
+            check_vmul!(C, A, B, atol)
+            check_vmul!(C, A, B', atol)
+            check_vmul!(C, A', B, atol)
+            check_vmul!(C, A', B', atol)
 
-            vmul!(C, A, B')
-            @test A * B' ≈ C atol = atol
+            # Hermitian forwards
+            check_vmul!(C, A, H, atol)
+            check_vmul!(C, H, A, atol)
+            check_vmul!(C, A, H', atol)
+            check_vmul!(C, H', A', atol)
+            # incomplete but these are just forwards
+            check_vmul!(C, A', H, atol)
+            check_vmul!(C, H', D, atol)
 
-            vmul!(C, A', B)
-            @test A' * B ≈ C atol = atol
-
-            vmul!(C, A', B')
-            @test A' * B' ≈ C atol = atol
-
-            D = Diagonal(rand(8))
-            vmul!(C, A, D)
-            @test A * D ≈ C atol = atol
+            # Diagonal
+            check_vmul!(C, A, D, atol)
+            check_vmul!(C, A', D, atol)
 
             copyto!(C, A)
             rvmul!(C, D)
@@ -50,7 +61,7 @@ let
             @test A - I ≈ C atol = atol
 
             if type == Float64
-                v = rand(8) .+ 0.5
+                v = rand(N) .+ 0.5
                 w = copy(v)
                 
                 vmin!(v, w)
@@ -68,30 +79,40 @@ let
                 v = copy(w)
                 vinv!(w)
                 @test w ≈ 1.0 ./ v atol = atol
+            else
+                # real adjoint + complex for Hermitian
+                R = rand(Float64, N, N)
+                check_vmul!(C, A, R', atol)
+                check_vmul!(C, A', R, atol)
+                check_vmul!(C, A', R', atol)
+
+                check_vmul!(C, R, A', atol)
+                check_vmul!(C, R', A, atol)
+                check_vmul!(C, R', A', atol)
             end
         end
 
 
 
         @testset "UDT transformations + rdivp! ($type)" begin
-            U = Matrix{Float64}(undef, 8, 8)
-            D = Vector{Float64}(undef, 8)
-            T = rand(8, 8)
+            U = Matrix{Float64}(undef, N, N)
+            D = Vector{Float64}(undef, N)
+            T = rand(N, N)
             X = copy(T)
             MonteCarlo.udt_AVX!(U, D, T)
             @test U * Diagonal(D) * T ≈ X
 
-            U = Matrix{type}(undef, 8, 8)
-            T = rand(type, 8, 8)
+            U = Matrix{type}(undef, N, N)
+            T = rand(type, N, N)
             X = copy(T)
-            pivot = Vector{Int64}(undef, 8)
-            tempv = Vector{type}(undef, 8)
+            pivot = Vector{Int64}(undef, N)
+            tempv = Vector{type}(undef, N)
             udt_AVX_pivot!(U, D, T)
             @test U * Diagonal(D) * T ≈ X
 
             copyto!(T, X)
-            pivot = Vector{Int64}(undef, 8)
-            tempv = Vector{type}(undef, 8)
+            pivot = Vector{Int64}(undef, N)
+            tempv = Vector{type}(undef, N)
             udt_AVX_pivot!(U, D, T, pivot, tempv, Val(false))
             # pivoting matrix
             P = zeros(length(pivot), length(pivot))
@@ -110,31 +131,32 @@ let
 
 
         @testset "BlockDiagonal ($type)" begin
+            n = div(N, 2)
             # setindex!
-            B = BlockDiagonal(zeros(4, 4), zeros(4, 4))
-            for i in 1:8, j in 1:8
-                if div(i, 5) == div(j, 5) # cause 5 / 5 = 1 is where we need to jump
-                    B[i, j] = 8i+j
-                    @test B[i, j] == 8i+j
+            B = BlockDiagonal(zeros(n, n), zeros(n, n))
+            for i in 1:N, j in 1:N
+                if div(i, n+1) == div(j, n+1) # cause 5 / 5 = 1 is where we need to jump
+                    B[i, j] = N*i+j
+                    @test B[i, j] == N*i+j
                 else
-                    @test_throws BoundsError B[i, j] = 8i+j
+                    @test_throws BoundsError B[i, j] = N*i+j
                 end
             end
 
             # typing
-            b1 = rand(type, 4, 4)
-            b2 = rand(type, 4, 4)
+            b1 = rand(type, n, n)
+            b2 = rand(type, n, n)
             atol = 100eps(Float64)
         
             B = BlockDiagonal(b1, b2)
             @test B isa BlockDiagonal{type, 2, Matrix{type}}
 
             # getindex
-            for i in 1:4, j in 1:4
+            for i in 1:n, j in 1:n
                 @test B[i, j] == b1[i, j]
-                @test B[4+i, 4+j] == b2[i, j]
-                @test B[4+i, j] == 0.0
-                @test B[i, 4+j] == 0.0
+                @test B[n+i, n+j] == b2[i, j]
+                @test B[n+i, j] == 0.0
+                @test B[i, n+j] == 0.0
             end
         
             # Matrix()
@@ -142,9 +164,9 @@ let
             M1 = Matrix(B1)
             @test M1 == B1
         
-            B2 = BlockDiagonal(rand(type, 4, 4), rand(type, 4, 4))
+            B2 = BlockDiagonal(rand(type, n, n), rand(type, n, n))
             M2 = Matrix(B2)
-            B3 = BlockDiagonal(rand(type, 4, 4), rand(type, 4, 4))
+            B3 = BlockDiagonal(rand(type, n, n), rand(type, n, n))
             M3 = Matrix(B3)
         
             # taylor exp
@@ -152,7 +174,7 @@ let
             T = MonteCarlo.taylor_exp(B)
             @test all(abs.(T .- E) .< 10_000eps.(abs.(E)))
 
-            # Test (avx) multiplications
+            # Test (avx) multiplications ---------------------------------------
             vmul!(B1, B2, B3)
             vmul!(M1, M2, M3)
             @test M1 ≈ B1 atol = atol
@@ -165,7 +187,7 @@ let
             vmul!(M1, adjoint(M2), M3)
             @test M1 ≈ B1 atol = atol
         
-            D = Diagonal(rand(8))
+            D = Diagonal(rand(N))
             vmul!(B1, B2, D)
             vmul!(M1, M2, D)
             @test M1 ≈ B1 atol = atol
@@ -204,9 +226,9 @@ let
         
             # Test UDT and rdivp!
             M2 = Matrix(B2)
-            D = rand(8)
-            pivot = Vector{Int64}(undef, 8)
-            tempv = Vector{type}(undef, 8)
+            D = rand(N)
+            pivot = Vector{Int64}(undef, N)
+            tempv = Vector{type}(undef, N)
             udt_AVX_pivot!(B1, D, B2, pivot, tempv, Val(false))
             
             P = zeros(length(pivot), length(pivot))
@@ -230,16 +252,17 @@ let
 
         
     @testset "Complex StructArray" begin
-        M1 = rand(ComplexF64, 8, 8)    
+        M1 = rand(ComplexF64, N, N)    
         C1 = StructArray(M1)
-        M2 = rand(ComplexF64, 8, 8)    
+        M2 = rand(ComplexF64, N, N)    
         C2 = StructArray(M2)
-        M3 = rand(ComplexF64, 8, 8)    
+        M3 = rand(ComplexF64, N, N)    
         C3 = StructArray(M3)
 
         # taylor exp
         E = exp(Matrix(M1))
         T = MonteCarlo.taylor_exp(C1)
+        atol = 100eps(Float64)
         @test all(abs.(T .- E) .< 10_000eps.(abs.(E)))
 
         @test C1 isa CMat64
@@ -263,12 +286,12 @@ let
         @test M1 ≈ C1
 
         # Diagonal
-        D = Diagonal(rand(8))
+        D = Diagonal(rand(N))
         vmul!(C1, C2, D)
         vmul!(M1, M2, D)
         @test M1 == C1
 
-        DC = Diagonal(rand(ComplexF64, 8))
+        DC = Diagonal(rand(ComplexF64, N))
         DCSA = Diagonal(StructArray(DC.diag))
         vmul!(C1, C2, DCSA)
         vmul!(M1, M2, DC)
@@ -325,11 +348,11 @@ let
 
         # Test UDT's, rdivp!
 
-        M2 = rand(ComplexF64, 8, 8)
+        M2 = rand(ComplexF64, N, N)
         C2 = StructArray(M2)
-        D = rand(Float64, 8)
-        pivot = Vector{Int64}(undef, 8)
-        tempv = Vector{ComplexF64}(undef, 8)
+        D = rand(Float64, N)
+        pivot = Vector{Int64}(undef, N)
+        tempv = Vector{ComplexF64}(undef, N)
         udt_AVX_pivot!(C1, D, C2, pivot, tempv, Val(false))
         P = zeros(length(pivot), length(pivot))
         for (i, j) in enumerate(pivot)
@@ -347,5 +370,21 @@ let
         udt_AVX_pivot!(C1, D, C2, pivot, tempv, Val(true))
         @test Matrix(C1) * Diagonal(D) * Matrix(C2) ≈ M2
 
+        # real adjoint + complex for Hermitian
+        R = rand(Float64, N, N)
+        copyto!(M2, C2) # just in case
+        vmul!(C1, C2, R')
+        @test C1 ≈ M2 * R' atol = atol
+        vmul!(C1, C2', R)
+        @test C1 ≈ M2' * R atol = atol
+        vmul!(C1, C2', R')
+        @test C1 ≈ M2' * R' atol = atol
+        
+        vmul!(C1, R, C2')
+        @test C1 ≈ R * M2' atol = atol
+        vmul!(C1, R', C2)
+        @test C1 ≈ R' * M2 atol = atol
+        vmul!(C1, R', C2')
+        @test C1 ≈ R' * M2' atol = atol
     end
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -298,6 +298,9 @@ let
         # Diagonal
         @test check_vmul!(C1, C2, D, M2, D, atol)
         @test check_vmul!(C1, C2', D, M2', D, atol)
+        @test check_vmul!(C1, R, D, R, D, atol)
+        @test check_vmul!(C1, R', D, R', D, atol)
+
         @test check_vmul!(C1, D, C2, D, M2, atol)
         @test check_vmul!(C1, D, C2', D, M2', atol)
         @test check_vmul!(C1, D, R, D, R, atol)


### PR DESCRIPTION
The hopping matrix and thus the its matrix exponential is Hermitian which means rather than $A_{ij} B_{jk}$ we can calculate $A_{ji} B_{jk}$ which is more cashe friendly. Using this speeds up the `add_*_slice_matrix_*()` functions:

- `multiply_slice_matrix_left!` -41%
- `multiply_slice_matrix_right!` -17%
- `multiply_slice_matrix_inv_left!` -34%
- `multiply_slice_matrix_inv_right!` -7%
- `multiply_daggered_slice_matrix_left!` ±0%

(1 - new/old time @ L = 8 square lattice)